### PR TITLE
feat: different left menu and exit workspace

### DIFF
--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -42,7 +42,7 @@ import { HttpStart } from '../http';
 import { InjectedMetadataStart } from '../injected_metadata';
 import { NotificationsStart } from '../notifications';
 import { IUiSettingsClient } from '../ui_settings';
-import { OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK, PATHS, WORKSPACE_APP_ID } from './constants';
+import { OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK, WORKSPACE_APP_ID } from './constants';
 import { ChromeDocTitle, DocTitleService } from './doc_title';
 import { ChromeNavControls, NavControlsService } from './nav_controls';
 import { ChromeNavLinks, NavLinksService, ChromeNavLink } from './nav_links';
@@ -184,7 +184,7 @@ export class ChromeService {
     const getWorkspaceUrl = (id: string) => {
       return workspaces?.formatUrlWithWorkspaceId(
         application.getUrlForApp(WORKSPACE_APP_ID, {
-          path: PATHS.update,
+          path: '/',
           absolute: true,
         }),
         id

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -42,7 +42,7 @@ import { HttpStart } from '../http';
 import { InjectedMetadataStart } from '../injected_metadata';
 import { NotificationsStart } from '../notifications';
 import { IUiSettingsClient } from '../ui_settings';
-import { OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK } from './constants';
+import { OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK, PATHS, WORKSPACE_APP_ID } from './constants';
 import { ChromeDocTitle, DocTitleService } from './doc_title';
 import { ChromeNavControls, NavControlsService } from './nav_controls';
 import { ChromeNavLinks, NavLinksService, ChromeNavLink } from './nav_links';
@@ -181,6 +181,16 @@ export class ChromeService {
       docTitle.reset();
     });
 
+    const getWorkspaceUrl = (id: string) => {
+      return workspaces?.formatUrlWithWorkspaceId(
+        application.getUrlForApp(WORKSPACE_APP_ID, {
+          path: PATHS.update,
+          absolute: true,
+        }),
+        id
+      );
+    };
+
     const exitWorkspace = async () => {
       let result;
       try {
@@ -201,6 +211,7 @@ export class ChromeService {
           }),
           text: result?.error,
         });
+        return;
       }
       await application.navigateToApp('home');
     };
@@ -285,10 +296,12 @@ export class ChromeService {
           navControlsExpandedRight$={navControls.getExpandedRight$()}
           onIsLockedUpdate={setIsNavDrawerLocked}
           exitWorkspace={exitWorkspace}
+          getWorkspaceUrl={getWorkspaceUrl}
           isLocked$={getIsNavDrawerLocked$}
           branding={injectedMetadata.getBranding()}
           survey={injectedMetadata.getSurvey()}
           currentWorkspace$={workspaces.client.currentWorkspace$}
+          workspaceList$={workspaces.client.workspaceList$}
         />
       ),
 

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -289,6 +289,8 @@ export class ChromeService {
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}
+          customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
+          recentlyAccessed$={recentlyAccessed.get$()}
           navControlsLeft$={navControls.getLeft$()}
           navControlsCenter$={navControls.getCenter$()}
           navControlsRight$={navControls.getRight$()}

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -270,7 +270,6 @@ export class ChromeService {
           badge$={badge$.pipe(takeUntil(this.stop$))}
           basePath={http.basePath}
           breadcrumbs$={breadcrumbs$.pipe(takeUntil(this.stop$))}
-          customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
           opensearchDashboardsDocLink={docLinks.links.opensearchDashboards.introduction}
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
@@ -279,7 +278,6 @@ export class ChromeService {
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}
-          recentlyAccessed$={recentlyAccessed.get$()}
           navControlsLeft$={navControls.getLeft$()}
           navControlsCenter$={navControls.getCenter$()}
           navControlsRight$={navControls.getRight$()}

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -289,8 +289,6 @@ export class ChromeService {
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}
-          customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
-          recentlyAccessed$={recentlyAccessed.get$()}
           navControlsLeft$={navControls.getLeft$()}
           navControlsCenter$={navControls.getCenter$()}
           navControlsRight$={navControls.getRight$()}

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -34,12 +34,8 @@ export const GITHUB_CREATE_ISSUE_LINK =
 
 export const WORKSPACE_APP_ID = 'workspace';
 
-export const WORKSPACE_ID_IN_SESSION_STORAGE = '_workspace_id_';
-
 export const PATHS = {
   create: '/create',
   overview: '/overview',
   update: '/update',
 };
-export const WORKSPACE_OP_TYPE_CREATE = 'create';
-export const WORKSPACE_OP_TYPE_UPDATE = 'update';

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -33,3 +33,7 @@ export const GITHUB_CREATE_ISSUE_LINK =
   'https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose';
 
 export const WORKSPACE_APP_ID = 'workspace';
+
+export const PATHS = {
+  list: '/list',
+};

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -31,3 +31,15 @@
 export const OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK = 'https://forum.opensearch.org/';
 export const GITHUB_CREATE_ISSUE_LINK =
   'https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose';
+
+export const WORKSPACE_APP_ID = 'workspace';
+
+export const WORKSPACE_ID_IN_SESSION_STORAGE = '_workspace_id_';
+
+export const PATHS = {
+  create: '/create',
+  overview: '/overview',
+  update: '/update',
+};
+export const WORKSPACE_OP_TYPE_CREATE = 'create';
+export const WORKSPACE_OP_TYPE_UPDATE = 'update';

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -33,9 +33,3 @@ export const GITHUB_CREATE_ISSUE_LINK =
   'https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose';
 
 export const WORKSPACE_APP_ID = 'workspace';
-
-export const PATHS = {
-  create: '/create',
-  overview: '/overview',
-  update: '/update',
-};

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -35,6 +35,7 @@ import sinon from 'sinon';
 import { StubBrowserStorage } from 'test_utils/stub_browser_storage';
 import { ChromeNavLink, DEFAULT_APP_CATEGORIES } from '../../..';
 import { httpServiceMock } from '../../../http/http_service.mock';
+import { ChromeRecentlyAccessedHistoryItem } from '../../recently_accessed';
 import { CollapsibleNav } from './collapsible_nav';
 import { workspacesServiceMock } from '../../../fatal_errors/fatal_errors_service.mock';
 
@@ -55,6 +56,15 @@ function mockLink({ title = 'discover', category }: Partial<ChromeNavLink>) {
     'data-test-subj': title,
   };
 }
+
+function mockRecentNavLink({ label = 'recent' }: Partial<ChromeRecentlyAccessedHistoryItem>) {
+  return {
+    label,
+    link: label,
+    id: label,
+  };
+}
+
 function mockProps() {
   return {
     appId$: new BehaviorSubject('test'),
@@ -64,6 +74,7 @@ function mockProps() {
     isNavOpen: false,
     homeHref: '/',
     navLinks$: new BehaviorSubject([]),
+    recentlyAccessed$: new BehaviorSubject([]),
     storage: new StubBrowserStorage(),
     onIsLockedUpdate: () => {},
     closeNav: () => {},
@@ -71,6 +82,7 @@ function mockProps() {
     navigateToUrl: () => Promise.resolve(),
     exitWorkspace: () => {},
     getWorkspaceUrl: (id: string) => '',
+    customNavLink$: new BehaviorSubject(undefined),
     currentWorkspace$: workspacesServiceMock.createStartContract().client.currentWorkspace$,
     workspaceList$: workspacesServiceMock.createStartContract().client.workspaceList$,
     branding: {
@@ -127,8 +139,19 @@ describe('CollapsibleNav', () => {
       mockLink({ title: 'canvas' }), // links should be able to be rendered top level as well
       mockLink({ title: 'logs', category: observability }),
     ];
+    const recentNavLinks = [
+      mockRecentNavLink({ label: 'recent 1' }),
+      mockRecentNavLink({ label: 'recent 2' }),
+    ];
+    const customNavLink = mockLink({ title: 'Custom link' });
     const component = mount(
-      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+        customNavLink$={new BehaviorSubject(customNavLink)}
+      />
     );
     expect(component).toMatchSnapshot();
   });
@@ -138,8 +161,14 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
+    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
     );
     expectShownNavLinksCount(component, 3);
     clickGroup(component, 'opensearchDashboards');
@@ -157,8 +186,14 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ title: 'categoryless' }),
     ];
+    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
     );
     component.setProps({
       closeNav: () => {
@@ -187,8 +222,14 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
+    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
     );
     // check if nav bar renders default mode custom logo
     expect(component).toMatchSnapshot();
@@ -208,8 +249,14 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
+    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
     );
     // check if nav bar renders dark mode custom logo
     component.setProps({

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -35,7 +35,6 @@ import sinon from 'sinon';
 import { StubBrowserStorage } from 'test_utils/stub_browser_storage';
 import { ChromeNavLink, DEFAULT_APP_CATEGORIES } from '../../..';
 import { httpServiceMock } from '../../../http/http_service.mock';
-import { ChromeRecentlyAccessedHistoryItem } from '../../recently_accessed';
 import { CollapsibleNav } from './collapsible_nav';
 import { workspacesServiceMock } from '../../../fatal_errors/fatal_errors_service.mock';
 
@@ -56,15 +55,6 @@ function mockLink({ title = 'discover', category }: Partial<ChromeNavLink>) {
     'data-test-subj': title,
   };
 }
-
-function mockRecentNavLink({ label = 'recent' }: Partial<ChromeRecentlyAccessedHistoryItem>) {
-  return {
-    label,
-    link: label,
-    id: label,
-  };
-}
-
 function mockProps() {
   return {
     appId$: new BehaviorSubject('test'),
@@ -74,7 +64,6 @@ function mockProps() {
     isNavOpen: false,
     homeHref: '/',
     navLinks$: new BehaviorSubject([]),
-    recentlyAccessed$: new BehaviorSubject([]),
     storage: new StubBrowserStorage(),
     onIsLockedUpdate: () => {},
     closeNav: () => {},
@@ -82,7 +71,6 @@ function mockProps() {
     navigateToUrl: () => Promise.resolve(),
     exitWorkspace: () => {},
     getWorkspaceUrl: (id: string) => '',
-    customNavLink$: new BehaviorSubject(undefined),
     currentWorkspace$: workspacesServiceMock.createStartContract().client.currentWorkspace$,
     workspaceList$: workspacesServiceMock.createStartContract().client.workspaceList$,
     branding: {
@@ -139,19 +127,8 @@ describe('CollapsibleNav', () => {
       mockLink({ title: 'canvas' }), // links should be able to be rendered top level as well
       mockLink({ title: 'logs', category: observability }),
     ];
-    const recentNavLinks = [
-      mockRecentNavLink({ label: 'recent 1' }),
-      mockRecentNavLink({ label: 'recent 2' }),
-    ];
-    const customNavLink = mockLink({ title: 'Custom link' });
     const component = mount(
-      <CollapsibleNav
-        {...mockProps()}
-        isNavOpen={true}
-        navLinks$={new BehaviorSubject(navLinks)}
-        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
-        customNavLink$={new BehaviorSubject(customNavLink)}
-      />
+      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
     );
     expect(component).toMatchSnapshot();
   });
@@ -161,14 +138,8 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
-    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav
-        {...mockProps()}
-        isNavOpen={true}
-        navLinks$={new BehaviorSubject(navLinks)}
-        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
-      />
+      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
     );
     expectShownNavLinksCount(component, 3);
     clickGroup(component, 'opensearchDashboards');
@@ -186,14 +157,8 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ title: 'categoryless' }),
     ];
-    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav
-        {...mockProps()}
-        isNavOpen={true}
-        navLinks$={new BehaviorSubject(navLinks)}
-        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
-      />
+      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
     );
     component.setProps({
       closeNav: () => {
@@ -222,14 +187,8 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
-    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav
-        {...mockProps()}
-        isNavOpen={true}
-        navLinks$={new BehaviorSubject(navLinks)}
-        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
-      />
+      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
     );
     // check if nav bar renders default mode custom logo
     expect(component).toMatchSnapshot();
@@ -249,14 +208,8 @@ describe('CollapsibleNav', () => {
       mockLink({ category: opensearchDashboards }),
       mockLink({ category: observability }),
     ];
-    const recentNavLinks = [mockRecentNavLink({})];
     const component = mount(
-      <CollapsibleNav
-        {...mockProps()}
-        isNavOpen={true}
-        navLinks$={new BehaviorSubject(navLinks)}
-        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
-      />
+      <CollapsibleNav {...mockProps()} isNavOpen={true} navLinks$={new BehaviorSubject(navLinks)} />
     );
     // check if nav bar renders dark mode custom logo
     component.setProps({

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -80,8 +80,11 @@ function mockProps() {
     closeNav: () => {},
     navigateToApp: () => Promise.resolve(),
     navigateToUrl: () => Promise.resolve(),
+    exitWorkspace: () => {},
+    getWorkspaceUrl: (id: string) => '',
     customNavLink$: new BehaviorSubject(undefined),
     currentWorkspace$: workspacesServiceMock.createStartContract().client.currentWorkspace$,
+    workspaceList$: workspacesServiceMock.createStartContract().client.workspaceList$,
     branding: {
       darkMode: false,
       mark: {

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -51,6 +51,7 @@ import { OnIsLockedUpdate } from './';
 import { createEuiListItem, isModifiedOrPrevented, createWorkspaceNavLink } from './nav_link';
 import { ChromeBranding } from '../../chrome_service';
 import { WorkspaceAttribute } from '../../../workspace';
+import { WORKSPACE_APP_ID, PATHS } from '../../constants';
 
 function getAllCategories(allCategorizedLinks: Record<string, ChromeNavLink[]>) {
   const allCategories = {} as Record<string, AppCategory | undefined>;
@@ -290,7 +291,16 @@ export function CollapsibleNav({
                   </p>
                 </EuiText>
               )}
-              <EuiText size="s" color="subdued" style={{ padding: '0 8px 8px' }}>
+              <EuiText
+                size="s"
+                color="subdued"
+                style={{ padding: '0 8px 8px' }}
+                onClick={async () => {
+                  await navigateToApp(WORKSPACE_APP_ID, {
+                    path: PATHS.list,
+                  });
+                }}
+              >
                 <p>
                   {i18n.translate('core.ui.SeeMoreWorkspace', {
                     defaultMessage: 'SEE MORE',

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -50,6 +50,7 @@ import { OnIsLockedUpdate } from './';
 import { createEuiListItem } from './nav_link';
 import { ChromeBranding } from '../../chrome_service';
 import { WorkspaceAttribute } from '../../../workspace';
+import { PATHS, WORKSPACE_APP_ID, WORKSPACE_ID_IN_SESSION_STORAGE } from '../../constants';
 
 function getAllCategories(allCategorizedLinks: Record<string, ChromeNavLink[]>) {
   const allCategories = {} as Record<string, AppCategory | undefined>;
@@ -202,7 +203,14 @@ export function CollapsibleNav({
         {/* Home, Alerts, Favorites, Projects and Admin outside workspace */}
         {!currentWorkspace && (
           <>
-            <EuiCollapsibleNavGroup onClick={closeNav} iconType={'logoOpenSearch'} title={'Home'} />
+            <EuiCollapsibleNavGroup
+              onClick={async () => {
+                closeNav();
+                await navigateToApp('home');
+              }}
+              iconType={'logoOpenSearch'}
+              title={'Home'}
+            />
             <EuiCollapsibleNavGroup onClick={closeNav} iconType={'bell'} title={'Alerts'} />
             <EuiCollapsibleNavGroup onClick={closeNav} iconType={'starEmpty'} title={'Favorites'} />
             <EuiCollapsibleNavGroup
@@ -218,7 +226,21 @@ export function CollapsibleNav({
         {currentWorkspace && (
           <>
             <EuiCollapsibleNavGroup iconType={'folderClosed'} title={currentWorkspace.name} />
-            <EuiCollapsibleNavGroup onClick={closeNav} iconType={'grid'} title={'Overview'} />
+            <EuiCollapsibleNavGroup
+              onClick={async () => {
+                closeNav();
+                await navigateToApp(WORKSPACE_APP_ID, {
+                  path:
+                    PATHS.update +
+                    '?' +
+                    WORKSPACE_ID_IN_SESSION_STORAGE +
+                    '=' +
+                    currentWorkspace.id,
+                });
+              }}
+              iconType={'grid'}
+              title={'Overview'}
+            />
           </>
         )}
 

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -125,7 +125,6 @@ export function CollapsibleNav({
   ...observables
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
-
   const appId = useObservable(observables.appId$, '');
   const currentWorkspace = useObservable(observables.currentWorkspace$);
   const workspaceList = useObservable(observables.workspaceList$, []).slice(0, 5);
@@ -216,12 +215,22 @@ export function CollapsibleNav({
                 await navigateToApp('home');
               }}
               iconType={'logoOpenSearch'}
-              title={'Home'}
+              title={i18n.translate('core.ui.primaryNavSection.home', {
+                defaultMessage: 'Home',
+              })}
             />
-            <EuiCollapsibleNavGroup onClick={closeNav} iconType={'bell'} title={'Alerts'} />
+            <EuiCollapsibleNavGroup
+              onClick={closeNav}
+              iconType={'bell'}
+              title={i18n.translate('core.ui.primaryNavSection.alerts', {
+                defaultMessage: 'Alerts',
+              })}
+            />
             <EuiCollapsibleNavGroup
               iconType={'starEmpty'}
-              title={'Favorites'}
+              title={i18n.translate('core.ui.primaryNavSection.favorites', {
+                defaultMessage: 'Favorites',
+              })}
               isCollapsible={true}
               initialIsOpen={true}
             >
@@ -242,7 +251,9 @@ export function CollapsibleNav({
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
               iconType={'folderClosed'}
-              title={'Workspaces'}
+              title={i18n.translate('core.ui.primaryNavSection.workspaces', {
+                defaultMessage: 'Workspaces',
+              })}
               isCollapsible={true}
               initialIsOpen={true}
             >
@@ -253,7 +264,7 @@ export function CollapsibleNav({
                   })}
                   listItems={workspaceList.map((workspace) => {
                     const href = getWorkspaceUrl(workspace.id);
-                    const { ...hydratedLink } = createWorkspaceNavLink(href, workspace, navLinks);
+                    const hydratedLink = createWorkspaceNavLink(href, workspace, navLinks);
                     return {
                       href,
                       ...hydratedLink,
@@ -287,7 +298,13 @@ export function CollapsibleNav({
                 </p>
               </EuiText>
             </EuiCollapsibleNavGroup>
-            <EuiCollapsibleNavGroup onClick={closeNav} iconType={'managementApp'} title={'Admin'} />
+            <EuiCollapsibleNavGroup
+              onClick={closeNav}
+              iconType={'managementApp'}
+              title={i18n.translate('core.ui.primaryNavSection.admin', {
+                defaultMessage: 'Admin',
+              })}
+            />
           </>
         )}
 
@@ -300,7 +317,9 @@ export function CollapsibleNav({
                 window.location.href = getWorkspaceUrl(currentWorkspace.id);
               }}
               iconType={'grid'}
-              title={'Overview'}
+              title={i18n.translate('core.ui.primaryNavSection.overview', {
+                defaultMessage: 'Overview',
+              })}
             />
           </>
         )}

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -43,7 +43,7 @@ import { groupBy, sortBy } from 'lodash';
 import React, { useRef } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
-import { ChromeNavLink } from '../..';
+import { ChromeNavLink, ChromeRecentlyAccessedHistoryItem } from '../..';
 import { AppCategory } from '../../../../types';
 import { InternalApplicationStart } from '../../../application';
 import { HttpStart } from '../../../http';
@@ -94,11 +94,13 @@ interface Props {
   isNavOpen: boolean;
   homeHref: string;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
+  recentlyAccessed$: Rx.Observable<ChromeRecentlyAccessedHistoryItem[]>;
   storage?: Storage;
   onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
+  customNavLink$: Rx.Observable<ChromeNavLink | undefined>;
   branding: ChromeBranding;
   exitWorkspace: () => void;
   getWorkspaceUrl: (id: string) => string;
@@ -123,6 +125,7 @@ export function CollapsibleNav({
   ...observables
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
+
   const appId = useObservable(observables.appId$, '');
   const currentWorkspace = useObservable(observables.currentWorkspace$);
   const workspaceList = useObservable(observables.workspaceList$, []).slice(0, 5);

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -103,6 +103,7 @@ interface Props {
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
   customNavLink$: Rx.Observable<ChromeNavLink | undefined>;
   branding: ChromeBranding;
+  exitWorkspace: () => void;
   currentWorkspace$: Rx.BehaviorSubject<WorkspaceAttribute | null>;
 }
 
@@ -114,6 +115,7 @@ export function CollapsibleNav({
   homeHref,
   storage = window.localStorage,
   onIsLockedUpdate,
+  exitWorkspace,
   closeNav,
   navigateToApp,
   navigateToUrl,
@@ -126,8 +128,8 @@ export function CollapsibleNav({
   const appId = useObservable(observables.appId$, '');
   const currentWorkspace = useObservable(observables.currentWorkspace$);
   const lockRef = useRef<HTMLButtonElement>(null);
-  const filterdLinks = getFilterLinks(currentWorkspace, navLinks);
-  const groupedNavLinks = groupBy(filterdLinks, (link) => link?.category?.id);
+  const filteredLinks = getFilterLinks(currentWorkspace, navLinks);
+  const groupedNavLinks = groupBy(filteredLinks, (link) => link?.category?.id);
   const { undefined: unknowns = [], ...allCategorizedLinks } = groupedNavLinks;
   const categoryDictionary = getAllCategories(allCategorizedLinks);
   const orderedCategories = getOrderedCategories(allCategorizedLinks, categoryDictionary);
@@ -334,6 +336,22 @@ export function CollapsibleNav({
         <EuiShowFor sizes={['l', 'xl']}>
           <EuiCollapsibleNavGroup>
             <EuiListGroup flush>
+              {/* Exit workspace button only within a workspace*/}
+              {currentWorkspace && (
+                <EuiListGroupItem
+                  data-test-subj="collapsible-nav-exit"
+                  size="xs"
+                  color="subdued"
+                  label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
+                    defaultMessage: 'Exit workspace',
+                  })}
+                  aria-label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
+                    defaultMessage: 'Exit workspace',
+                  })}
+                  onClick={exitWorkspace}
+                  iconType={'exit'}
+                />
+              )}
               <EuiListGroupItem
                 data-test-subj="collapsible-nav-lock"
                 buttonRef={lockRef}

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -332,60 +332,62 @@ export function CollapsibleNav({
           </EuiCollapsibleNavGroup>
         ))}
 
-        {/* Docking button only for larger screens that can support it*/}
-        <EuiShowFor sizes={['l', 'xl']}>
-          <EuiCollapsibleNavGroup>
-            <EuiListGroup flush>
-              {/* Exit workspace button only within a workspace*/}
-              {currentWorkspace && (
-                <EuiListGroupItem
-                  data-test-subj="collapsible-nav-exit"
-                  size="xs"
-                  color="subdued"
-                  label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
-                    defaultMessage: 'Exit workspace',
-                  })}
-                  aria-label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
-                    defaultMessage: 'Exit workspace',
-                  })}
-                  onClick={exitWorkspace}
-                  iconType={'exit'}
-                />
-              )}
+        <EuiCollapsibleNavGroup>
+          <EuiListGroup flush>
+            {/* Exit workspace button only within a workspace*/}
+            {currentWorkspace && (
               <EuiListGroupItem
-                data-test-subj="collapsible-nav-lock"
-                buttonRef={lockRef}
+                data-test-subj="collapsible-nav-exit"
                 size="xs"
                 color="subdued"
-                label={
-                  isLocked
-                    ? i18n.translate('core.ui.primaryNavSection.undockLabel', {
-                        defaultMessage: 'Undock navigation',
-                      })
-                    : i18n.translate('core.ui.primaryNavSection.dockLabel', {
-                        defaultMessage: 'Dock navigation',
-                      })
-                }
-                aria-label={
-                  isLocked
-                    ? i18n.translate('core.ui.primaryNavSection.undockAriaLabel', {
-                        defaultMessage: 'Undock primary navigation',
-                      })
-                    : i18n.translate('core.ui.primaryNavSection.dockAriaLabel', {
-                        defaultMessage: 'Dock primary navigation',
-                      })
-                }
-                onClick={() => {
-                  onIsLockedUpdate(!isLocked);
-                  if (lockRef.current) {
-                    lockRef.current.focus();
-                  }
-                }}
-                iconType={isLocked ? 'lock' : 'lockOpen'}
+                label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
+                  defaultMessage: 'Exit workspace',
+                })}
+                aria-label={i18n.translate('core.ui.primaryNavSection.exitWorkspaceLabel', {
+                  defaultMessage: 'Exit workspace',
+                })}
+                onClick={exitWorkspace}
+                iconType={'exit'}
               />
-            </EuiListGroup>
-          </EuiCollapsibleNavGroup>
-        </EuiShowFor>
+            )}
+            {/* Docking button only for larger screens that can support it*/}
+            {
+              <EuiShowFor sizes={['l', 'xl']}>
+                <EuiListGroupItem
+                  data-test-subj="collapsible-nav-lock"
+                  buttonRef={lockRef}
+                  size="xs"
+                  color="subdued"
+                  label={
+                    isLocked
+                      ? i18n.translate('core.ui.primaryNavSection.undockLabel', {
+                          defaultMessage: 'Undock navigation',
+                        })
+                      : i18n.translate('core.ui.primaryNavSection.dockLabel', {
+                          defaultMessage: 'Dock navigation',
+                        })
+                  }
+                  aria-label={
+                    isLocked
+                      ? i18n.translate('core.ui.primaryNavSection.undockAriaLabel', {
+                          defaultMessage: 'Undock primary navigation',
+                        })
+                      : i18n.translate('core.ui.primaryNavSection.dockAriaLabel', {
+                          defaultMessage: 'Dock primary navigation',
+                        })
+                  }
+                  onClick={() => {
+                    onIsLockedUpdate(!isLocked);
+                    if (lockRef.current) {
+                      lockRef.current.focus();
+                    }
+                  }}
+                  iconType={isLocked ? 'lock' : 'lockOpen'}
+                />
+              </EuiShowFor>
+            }
+          </EuiListGroup>
+        </EuiCollapsibleNavGroup>
       </EuiFlexItem>
     </EuiCollapsibleNav>
   );

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -43,7 +43,7 @@ import { groupBy, sortBy } from 'lodash';
 import React, { useRef } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
-import { ChromeNavLink, ChromeRecentlyAccessedHistoryItem } from '../..';
+import { ChromeNavLink } from '../..';
 import { AppCategory } from '../../../../types';
 import { InternalApplicationStart } from '../../../application';
 import { HttpStart } from '../../../http';
@@ -94,13 +94,11 @@ interface Props {
   isNavOpen: boolean;
   homeHref: string;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
-  recentlyAccessed$: Rx.Observable<ChromeRecentlyAccessedHistoryItem[]>;
   storage?: Storage;
   onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
-  customNavLink$: Rx.Observable<ChromeNavLink | undefined>;
   branding: ChromeBranding;
   exitWorkspace: () => void;
   getWorkspaceUrl: (id: string) => string;
@@ -125,7 +123,6 @@ export function CollapsibleNav({
   ...observables
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
-
   const appId = useObservable(observables.appId$, '');
   const currentWorkspace = useObservable(observables.currentWorkspace$);
   const workspaceList = useObservable(observables.workspaceList$, []).slice(0, 5);

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -43,7 +43,7 @@ import { groupBy, sortBy } from 'lodash';
 import React, { useRef } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
-import { ChromeNavLink } from '../..';
+import { ChromeNavLink, ChromeRecentlyAccessedHistoryItem } from '../..';
 import { AppCategory } from '../../../../types';
 import { InternalApplicationStart } from '../../../application';
 import { HttpStart } from '../../../http';
@@ -95,11 +95,13 @@ interface Props {
   isNavOpen: boolean;
   homeHref: string;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
+  recentlyAccessed$: Rx.Observable<ChromeRecentlyAccessedHistoryItem[]>;
   storage?: Storage;
   onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
+  customNavLink$: Rx.Observable<ChromeNavLink | undefined>;
   branding: ChromeBranding;
   exitWorkspace: () => void;
   getWorkspaceUrl: (id: string) => string;
@@ -124,6 +126,7 @@ export function CollapsibleNav({
   ...observables
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
+
   const appId = useObservable(observables.appId$, '');
   const currentWorkspace = useObservable(observables.currentWorkspace$);
   const workspaceList = useObservable(observables.workspaceList$, []).slice(0, 5);

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -51,7 +51,6 @@ import { OnIsLockedUpdate } from './';
 import { createEuiListItem, isModifiedOrPrevented, createWorkspaceNavLink } from './nav_link';
 import { ChromeBranding } from '../../chrome_service';
 import { WorkspaceAttribute } from '../../../workspace';
-import { PATHS, WORKSPACE_APP_ID, WORKSPACE_ID_IN_SESSION_STORAGE } from '../../constants';
 
 function getAllCategories(allCategorizedLinks: Record<string, ChromeNavLink[]>) {
   const allCategories = {} as Record<string, AppCategory | undefined>;
@@ -297,16 +296,8 @@ export function CollapsibleNav({
           <>
             <EuiCollapsibleNavGroup iconType={'folderClosed'} title={currentWorkspace.name} />
             <EuiCollapsibleNavGroup
-              onClick={async () => {
-                closeNav();
-                await navigateToApp(WORKSPACE_APP_ID, {
-                  path:
-                    PATHS.update +
-                    '?' +
-                    WORKSPACE_ID_IN_SESSION_STORAGE +
-                    '=' +
-                    currentWorkspace.id,
-                });
+              onClick={() => {
+                window.location.href = getWorkspaceUrl(currentWorkspace.id);
               }}
               iconType={'grid'}
               title={'Overview'}

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -56,6 +56,8 @@ function mockProps() {
     isVisible$: new BehaviorSubject(true),
     opensearchDashboardsDocLink: '/docs',
     navLinks$: new BehaviorSubject([]),
+    customNavLink$: new BehaviorSubject(undefined),
+    recentlyAccessed$: new BehaviorSubject([]),
     forceAppSwitcherNavigation$: new BehaviorSubject(false),
     helpExtension$: new BehaviorSubject(undefined),
     helpSupportUrl$: new BehaviorSubject(''),
@@ -96,13 +98,24 @@ describe('Header', () => {
     const navLinks$ = new BehaviorSubject([
       { id: 'opensearchDashboards', title: 'opensearchDashboards', baseUrl: '', href: '' },
     ]);
+    const customNavLink$ = new BehaviorSubject({
+      id: 'cloud-deployment-link',
+      title: 'Manage cloud deployment',
+      baseUrl: '',
+      href: '',
+    });
+    const recentlyAccessed$ = new BehaviorSubject([
+      { link: '', label: 'dashboard', id: 'dashboard' },
+    ]);
     const component = mountWithIntl(
       <Header
         {...mockProps()}
         isVisible$={isVisible$}
         breadcrumbs$={breadcrumbs$}
         navLinks$={navLinks$}
+        recentlyAccessed$={recentlyAccessed$}
         isLocked$={isLocked$}
+        customNavLink$={customNavLink$}
       />
     );
     expect(component.find('EuiHeader').exists()).toBeFalsy();

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -56,8 +56,6 @@ function mockProps() {
     isVisible$: new BehaviorSubject(true),
     opensearchDashboardsDocLink: '/docs',
     navLinks$: new BehaviorSubject([]),
-    customNavLink$: new BehaviorSubject(undefined),
-    recentlyAccessed$: new BehaviorSubject([]),
     forceAppSwitcherNavigation$: new BehaviorSubject(false),
     helpExtension$: new BehaviorSubject(undefined),
     helpSupportUrl$: new BehaviorSubject(''),
@@ -98,24 +96,13 @@ describe('Header', () => {
     const navLinks$ = new BehaviorSubject([
       { id: 'opensearchDashboards', title: 'opensearchDashboards', baseUrl: '', href: '' },
     ]);
-    const customNavLink$ = new BehaviorSubject({
-      id: 'cloud-deployment-link',
-      title: 'Manage cloud deployment',
-      baseUrl: '',
-      href: '',
-    });
-    const recentlyAccessed$ = new BehaviorSubject([
-      { link: '', label: 'dashboard', id: 'dashboard' },
-    ]);
     const component = mountWithIntl(
       <Header
         {...mockProps()}
         isVisible$={isVisible$}
         breadcrumbs$={breadcrumbs$}
         navLinks$={navLinks$}
-        recentlyAccessed$={recentlyAccessed$}
         isLocked$={isLocked$}
-        customNavLink$={customNavLink$}
       />
     );
     expect(component.find('EuiHeader').exists()).toBeFalsy();

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -70,6 +70,8 @@ function mockProps() {
     isLocked$: new BehaviorSubject(false),
     loadingCount$: new BehaviorSubject(0),
     onIsLockedUpdate: () => {},
+    exitWorkspace: () => {},
+    getWorkspaceUrl: (id: string) => '',
     branding: {
       darkMode: false,
       logo: { defaultUrl: '/' },
@@ -78,6 +80,7 @@ function mockProps() {
     },
     survey: '/',
     currentWorkspace$: workspacesServiceMock.createStartContract().client.currentWorkspace$,
+    workspaceList$: workspacesServiceMock.createStartContract().client.workspaceList$,
   };
 }
 

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -82,9 +82,11 @@ export interface HeaderProps {
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
   exitWorkspace: () => void;
+  getWorkspaceUrl: (id: string) => string;
   branding: ChromeBranding;
   survey: string | undefined;
   currentWorkspace$: BehaviorSubject<WorkspaceAttribute | null>;
+  workspaceList$: BehaviorSubject<WorkspaceAttribute[]>;
 }
 
 export function Header({
@@ -94,6 +96,7 @@ export function Header({
   basePath,
   onIsLockedUpdate,
   exitWorkspace,
+  getWorkspaceUrl,
   homeHref,
   branding,
   survey,
@@ -243,6 +246,7 @@ export function Header({
           navigateToUrl={application.navigateToUrl}
           onIsLockedUpdate={onIsLockedUpdate}
           exitWorkspace={exitWorkspace}
+          getWorkspaceUrl={getWorkspaceUrl}
           closeNav={() => {
             setIsNavOpen(false);
             if (toggleCollapsibleNavRef.current) {
@@ -251,6 +255,7 @@ export function Header({
           }}
           branding={branding}
           currentWorkspace$={observables.currentWorkspace$}
+          workspaceList$={observables.workspaceList$}
         />
       </header>
     </>

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -44,7 +44,13 @@ import React, { createRef, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { LoadingIndicator } from '../';
-import { ChromeBadge, ChromeBreadcrumb, ChromeNavControl, ChromeNavLink } from '../..';
+import {
+  ChromeBadge,
+  ChromeBreadcrumb,
+  ChromeNavControl,
+  ChromeNavLink,
+  ChromeRecentlyAccessedHistoryItem,
+} from '../..';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { ChromeHelpExtension, ChromeBranding } from '../../chrome_service';
@@ -65,10 +71,12 @@ export interface HeaderProps {
   appTitle$: Observable<string>;
   badge$: Observable<ChromeBadge | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
+  customNavLink$: Observable<ChromeNavLink | undefined>;
   homeHref: string;
   isVisible$: Observable<boolean>;
   opensearchDashboardsDocLink: string;
   navLinks$: Observable<ChromeNavLink[]>;
+  recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
   forceAppSwitcherNavigation$: Observable<boolean>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
@@ -239,6 +247,7 @@ export function Header({
           id={navId}
           isLocked={isLocked}
           navLinks$={observables.navLinks$}
+          recentlyAccessed$={observables.recentlyAccessed$}
           isNavOpen={isNavOpen}
           homeHref={homeHref}
           basePath={basePath}
@@ -253,6 +262,7 @@ export function Header({
               toggleCollapsibleNavRef.current.focus();
             }
           }}
+          customNavLink$={observables.customNavLink$}
           branding={branding}
           currentWorkspace$={observables.currentWorkspace$}
           workspaceList$={observables.workspaceList$}

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -44,14 +44,8 @@ import React, { createRef, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { LoadingIndicator } from '../';
-import {
-  ChromeBadge,
-  ChromeBreadcrumb,
-  ChromeNavControl,
-  ChromeNavLink,
-  ChromeRecentlyAccessedHistoryItem,
-} from '../..';
-import { InternalApplicationStart } from '../../../application/types';
+import { ChromeBadge, ChromeBreadcrumb, ChromeNavControl, ChromeNavLink } from '../..';
+import { InternalApplicationStart } from '../../../application';
 import { HttpStart } from '../../../http';
 import { ChromeHelpExtension, ChromeBranding } from '../../chrome_service';
 import { OnIsLockedUpdate } from './';
@@ -71,12 +65,10 @@ export interface HeaderProps {
   appTitle$: Observable<string>;
   badge$: Observable<ChromeBadge | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
-  customNavLink$: Observable<ChromeNavLink | undefined>;
   homeHref: string;
   isVisible$: Observable<boolean>;
   opensearchDashboardsDocLink: string;
   navLinks$: Observable<ChromeNavLink[]>;
-  recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
   forceAppSwitcherNavigation$: Observable<boolean>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
@@ -247,7 +239,6 @@ export function Header({
           id={navId}
           isLocked={isLocked}
           navLinks$={observables.navLinks$}
-          recentlyAccessed$={observables.recentlyAccessed$}
           isNavOpen={isNavOpen}
           homeHref={homeHref}
           basePath={basePath}
@@ -262,7 +253,6 @@ export function Header({
               toggleCollapsibleNavRef.current.focus();
             }
           }}
-          customNavLink$={observables.customNavLink$}
           branding={branding}
           currentWorkspace$={observables.currentWorkspace$}
           workspaceList$={observables.workspaceList$}

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -44,13 +44,7 @@ import React, { createRef, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { LoadingIndicator } from '../';
-import {
-  ChromeBadge,
-  ChromeBreadcrumb,
-  ChromeNavControl,
-  ChromeNavLink,
-  ChromeRecentlyAccessedHistoryItem,
-} from '../..';
+import { ChromeBadge, ChromeBreadcrumb, ChromeNavControl, ChromeNavLink } from '../..';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { ChromeHelpExtension, ChromeBranding } from '../../chrome_service';
@@ -71,12 +65,10 @@ export interface HeaderProps {
   appTitle$: Observable<string>;
   badge$: Observable<ChromeBadge | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
-  customNavLink$: Observable<ChromeNavLink | undefined>;
   homeHref: string;
   isVisible$: Observable<boolean>;
   opensearchDashboardsDocLink: string;
   navLinks$: Observable<ChromeNavLink[]>;
-  recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
   forceAppSwitcherNavigation$: Observable<boolean>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
@@ -244,7 +236,6 @@ export function Header({
           id={navId}
           isLocked={isLocked}
           navLinks$={observables.navLinks$}
-          recentlyAccessed$={observables.recentlyAccessed$}
           isNavOpen={isNavOpen}
           homeHref={homeHref}
           basePath={basePath}
@@ -258,7 +249,6 @@ export function Header({
               toggleCollapsibleNavRef.current.focus();
             }
           }}
-          customNavLink$={observables.customNavLink$}
           branding={branding}
           currentWorkspace$={observables.currentWorkspace$}
         />

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -44,8 +44,14 @@ import React, { createRef, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { LoadingIndicator } from '../';
-import { ChromeBadge, ChromeBreadcrumb, ChromeNavControl, ChromeNavLink } from '../..';
-import { InternalApplicationStart } from '../../../application';
+import {
+  ChromeBadge,
+  ChromeBreadcrumb,
+  ChromeNavControl,
+  ChromeNavLink,
+  ChromeRecentlyAccessedHistoryItem,
+} from '../..';
+import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { ChromeHelpExtension, ChromeBranding } from '../../chrome_service';
 import { OnIsLockedUpdate } from './';
@@ -65,10 +71,12 @@ export interface HeaderProps {
   appTitle$: Observable<string>;
   badge$: Observable<ChromeBadge | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
+  customNavLink$: Observable<ChromeNavLink | undefined>;
   homeHref: string;
   isVisible$: Observable<boolean>;
   opensearchDashboardsDocLink: string;
   navLinks$: Observable<ChromeNavLink[]>;
+  recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
   forceAppSwitcherNavigation$: Observable<boolean>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
@@ -239,6 +247,7 @@ export function Header({
           id={navId}
           isLocked={isLocked}
           navLinks$={observables.navLinks$}
+          recentlyAccessed$={observables.recentlyAccessed$}
           isNavOpen={isNavOpen}
           homeHref={homeHref}
           basePath={basePath}
@@ -253,6 +262,7 @@ export function Header({
               toggleCollapsibleNavRef.current.focus();
             }
           }}
+          customNavLink$={observables.customNavLink$}
           branding={branding}
           currentWorkspace$={observables.currentWorkspace$}
           workspaceList$={observables.workspaceList$}

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -89,6 +89,7 @@ export interface HeaderProps {
   isLocked$: Observable<boolean>;
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
+  exitWorkspace: () => void;
   branding: ChromeBranding;
   survey: string | undefined;
   currentWorkspace$: BehaviorSubject<WorkspaceAttribute | null>;
@@ -100,6 +101,7 @@ export function Header({
   application,
   basePath,
   onIsLockedUpdate,
+  exitWorkspace,
   homeHref,
   branding,
   survey,
@@ -249,6 +251,7 @@ export function Header({
           navigateToApp={application.navigateToApp}
           navigateToUrl={application.navigateToUrl}
           onIsLockedUpdate={onIsLockedUpdate}
+          exitWorkspace={exitWorkspace}
           closeNav={() => {
             setIsNavOpen(false);
             if (toggleCollapsibleNavRef.current) {

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -165,20 +165,21 @@ export function createWorkspaceNavLink(
   workspace: WorkspaceAttribute,
   navLinks: ChromeNavLink[]
 ): WorkspaceNavLink {
-  let titleAndAriaLabel = workspace.name;
+  const label = workspace.name;
+  let titleAndAriaLabel = label;
   const navLink = navLinks.find((nl) => href.startsWith(nl.baseUrl));
   if (navLink) {
     titleAndAriaLabel = i18n.translate('core.ui.workspaceLinks.linkItem.screenReaderLabel', {
       defaultMessage: '{workspaceItemLinkName}, type: {pageType}',
       values: {
-        workspaceItemLinkName: name,
+        workspaceItemLinkName: label,
         pageType: navLink.title,
       },
     });
   }
 
   return {
-    label: titleAndAriaLabel,
+    label,
     title: titleAndAriaLabel,
     'aria-label': titleAndAriaLabel,
   };

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -31,7 +31,12 @@
 import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
-import { ChromeNavLink, ChromeRecentlyAccessedHistoryItem, CoreStart } from '../../..';
+import {
+  ChromeNavLink,
+  ChromeRecentlyAccessedHistoryItem,
+  CoreStart,
+  WorkspaceAttribute,
+} from '../../..';
 import { HttpStart } from '../../../http';
 import { InternalApplicationStart } from '../../../application/types';
 import { relativeToAbsolute } from '../../nav_links/to_nav_link';
@@ -146,5 +151,35 @@ export function createRecentNavLink(
         navigateToUrl(href);
       }
     },
+  };
+}
+
+export interface WorkspaceNavLink {
+  label: string;
+  title: string;
+  'aria-label': string;
+}
+
+export function createWorkspaceNavLink(
+  href: string,
+  workspace: WorkspaceAttribute,
+  navLinks: ChromeNavLink[]
+): WorkspaceNavLink {
+  let titleAndAriaLabel = workspace.name;
+  const navLink = navLinks.find((nl) => href.startsWith(nl.baseUrl));
+  if (navLink) {
+    titleAndAriaLabel = i18n.translate('core.ui.workspaceLinks.linkItem.screenReaderLabel', {
+      defaultMessage: '{workspaceItemLinkName}, type: {pageType}',
+      values: {
+        workspaceItemLinkName: name,
+        pageType: navLink.title,
+      },
+    });
+  }
+
+  return {
+    label: titleAndAriaLabel,
+    title: titleAndAriaLabel,
+    'aria-label': titleAndAriaLabel,
   };
 }

--- a/src/plugins/workspace/public/components/workspace_app.tsx
+++ b/src/plugins/workspace/public/components/workspace_app.tsx
@@ -5,11 +5,11 @@
 
 import React, { useEffect } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
-import { Route, Switch, useLocation } from 'react-router-dom';
-
+import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import { ROUTES } from './routes';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { createBreadcrumbsFromPath } from './utils/breadcrumbs';
+import { PATHS } from '../../common/constants';
 
 export const WorkspaceApp = ({ appBasePath }: { appBasePath: string }) => {
   const {
@@ -31,6 +31,7 @@ export const WorkspaceApp = ({ appBasePath }: { appBasePath: string }) => {
         {ROUTES.map(({ path, Component, exact }) => (
           <Route key={path} path={path} render={() => <Component />} exact={exact ?? false} />
         ))}
+        <Redirect from="/" to={PATHS.update} />
       </Switch>
     </I18nProvider>
   );

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -112,12 +112,6 @@ export class WorkspacesPlugin implements Plugin<{}, {}> {
 
   public start(core: CoreStart) {
     mountDropdownList(core);
-
-    core.chrome.setCustomNavLink({
-      title: i18n.translate('workspace.nav.title', { defaultMessage: 'Workspace Overview' }),
-      baseUrl: core.http.basePath.get(),
-      href: core.application.getUrlForApp(WORKSPACE_APP_ID, { path: PATHS.update }),
-    });
     this._changeSavedObjectCurrentWorkspace();
     return {};
   }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

### Issues Resolved

1. Different left menu when inside and outside workspace. (See screenshots below)
2. Enable users to exit workspace through "Exit workspace" button on the left menu.
3. Implement a dropdown list for workspaces when outside workspaces. Users can enter workspace by clicking the workspace shown in the list. If there are more than 5 workspaces, only show the first 5 of them.
4. For outside workspace menu, implement "Home" button directing to OpenSearch Dashboards homepage.
5. For outside workspace menu, implement "SEE MORE" directing to workspace lists page.
6. For inside workspace menu, implement "Overview" button directing workspace update page.

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

Outside workspace:
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/f1be0f91-5584-4c1e-8954-44091803251b)

Inside workspace:
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/c1629a56-18b0-4901-b6f8-935a717f4021)


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
