### PR TITLE
allow user to turn on/off workspace from advance settings

### DIFF
--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -182,7 +182,7 @@ export class ChromeService {
     });
 
     const getWorkspaceUrl = (id: string) => {
-      return workspaces?.formatUrlWithWorkspaceId(
+      return workspaces.formatUrlWithWorkspaceId(
         application.getUrlForApp(WORKSPACE_APP_ID, {
           path: '/',
           absolute: true,
@@ -194,7 +194,7 @@ export class ChromeService {
     const exitWorkspace = async () => {
       let result;
       try {
-        result = await workspaces?.client.exitWorkspace();
+        result = await workspaces.client.exitWorkspace();
       } catch (error) {
         notifications?.toasts.addDanger({
           title: i18n.translate('workspace.exit.failed', {

--- a/src/core/public/core_app/core_app.ts
+++ b/src/core/public/core_app/core_app.ts
@@ -42,14 +42,12 @@ import type { IUiSettingsClient } from '../ui_settings';
 import type { InjectedMetadataSetup } from '../injected_metadata';
 import { renderApp as renderErrorApp, setupUrlOverflowDetection } from './errors';
 import { renderApp as renderStatusApp } from './status';
-import { WorkspacesSetup } from '../workspace';
 
 interface SetupDeps {
   application: InternalApplicationSetup;
   http: HttpSetup;
   injectedMetadata: InjectedMetadataSetup;
   notifications: NotificationsSetup;
-  workspaces: WorkspacesSetup;
 }
 
 interface StartDeps {

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -163,14 +163,14 @@ export class CoreSystem {
       const http = this.http.setup({ injectedMetadata, fatalErrors: this.fatalErrorsSetup });
       const uiSettings = this.uiSettings.setup({ http, injectedMetadata });
       const notifications = this.notifications.setup({ uiSettings });
-      const workspaces = await this.workspaces.setup({ http });
+      const workspaces = await this.workspaces.setup({ http, uiSettings });
 
       const pluginDependencies = this.plugins.getOpaqueIds();
       const context = this.context.setup({
         pluginDependencies: new Map([...pluginDependencies]),
       });
       const application = this.application.setup({ context, http });
-      this.coreApp.setup({ application, http, injectedMetadata, notifications, workspaces });
+      this.coreApp.setup({ application, http, injectedMetadata, notifications });
 
       const core: InternalCoreSetup = {
         application,
@@ -204,7 +204,6 @@ export class CoreSystem {
       const uiSettings = await this.uiSettings.start();
       const docLinks = this.docLinks.start({ injectedMetadata });
       const http = await this.http.start();
-      const workspaces = await this.workspaces.start();
       const savedObjects = await this.savedObjects.start({ http });
       const i18n = await this.i18n.start();
       const fatalErrors = await this.fatalErrors.start();
@@ -226,6 +225,7 @@ export class CoreSystem {
         targetDomElement: notificationsTargetDomElement,
       });
       const application = await this.application.start({ http, overlays });
+      const workspaces = await this.workspaces.start();
       const chrome = await this.chrome.start({
         application,
         docLinks,

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -98,6 +98,11 @@ export interface IBasePath {
   get: () => string;
 
   /**
+   * Gets the `basePath
+   */
+  getBasePath: () => string;
+
+  /**
    * Prepends `path` with the basePath + workspace.
    */
   prepend: (url: string) => string;

--- a/src/core/public/ui_settings/ui_settings_service.mock.ts
+++ b/src/core/public/ui_settings/ui_settings_service.mock.ts
@@ -33,7 +33,7 @@ import type { PublicMethodsOf } from '@osd/utility-types';
 import { UiSettingsService } from './';
 import { IUiSettingsClient } from './types';
 
-const createSetupContractMock = () => {
+const createUiSettingsClientMock = () => {
   const setupContract: jest.Mocked<IUiSettingsClient> = {
     getAll: jest.fn(),
     get: jest.fn(),
@@ -66,12 +66,13 @@ const createMock = () => {
     stop: jest.fn(),
   };
 
-  mocked.setup.mockReturnValue(createSetupContractMock());
+  mocked.setup.mockReturnValue(createUiSettingsClientMock());
+  mocked.start.mockReturnValue(createUiSettingsClientMock());
   return mocked;
 };
 
 export const uiSettingsServiceMock = {
   create: createMock,
-  createSetupContract: createSetupContractMock,
-  createStartContract: createSetupContractMock,
+  createSetupContract: createUiSettingsClientMock,
+  createStartContract: createUiSettingsClientMock,
 };

--- a/src/core/public/workspace/workspaces_client.ts
+++ b/src/core/public/workspace/workspaces_client.ts
@@ -70,10 +70,12 @@ export class WorkspacesClient {
         }
       }
     );
+  }
 
-    /**
-     * Initialize workspace list
-     */
+  /**
+   * Initialize workspace list
+   */
+  init() {
     this.updateWorkspaceListAndNotify();
   }
 

--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -7,7 +7,6 @@ import { WorkspacesClient, WorkspacesClientContract } from './workspaces_client'
 import type { WorkspaceAttribute } from '../../server/types';
 import { HttpSetup } from '../http';
 import { IUiSettingsClient } from '../ui_settings';
-import { getWorkspaceIdFromUrl } from '../utils/workspace';
 
 /**
  * @public
@@ -32,12 +31,7 @@ export class WorkspacesService implements CoreService<WorkspacesSetup, Workspace
     this.client = new WorkspacesClient(http);
 
     // If workspace was disabled while opening a workspace url, navigate to basePath
-    if (uiSettings.get('workspace:enabled') === false) {
-      const workspaceId = getWorkspaceIdFromUrl(window.location.href);
-      if (workspaceId) {
-        window.location.href = http.basePath.getBasePath();
-      }
-    } else {
+    if (uiSettings.get('workspace:enabled') === true) {
       this.client.init();
     }
 

--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -29,15 +29,18 @@ export class WorkspacesService implements CoreService<WorkspacesSetup, Workspace
     this.formatUrlWithWorkspaceId = formatFn;
   }
   public async setup({ http, uiSettings }: { http: HttpSetup; uiSettings: IUiSettingsClient }) {
+    this.client = new WorkspacesClient(http);
+
     // If workspace was disabled while opening a workspace url, navigate to basePath
     if (uiSettings.get('workspace:enabled') === false) {
       const workspaceId = getWorkspaceIdFromUrl(window.location.href);
       if (workspaceId) {
         window.location.href = http.basePath.getBasePath();
       }
+    } else {
+      this.client.init();
     }
 
-    this.client = new WorkspacesClient(http);
     return {
       client: this.client,
       formatUrlWithWorkspaceId: (url: string, id: string) => this.formatUrlWithWorkspaceId(url, id),

--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -6,6 +6,8 @@ import { CoreService } from 'src/core/types';
 import { WorkspacesClient, WorkspacesClientContract } from './workspaces_client';
 import type { WorkspaceAttribute } from '../../server/types';
 import { HttpSetup } from '../http';
+import { IUiSettingsClient } from '../ui_settings';
+import { getWorkspaceIdFromUrl } from '../utils/workspace';
 
 /**
  * @public
@@ -26,7 +28,15 @@ export class WorkspacesService implements CoreService<WorkspacesSetup, Workspace
   private setFormatUrlWithWorkspaceId(formatFn: WorkspacesStart['formatUrlWithWorkspaceId']) {
     this.formatUrlWithWorkspaceId = formatFn;
   }
-  public async setup({ http }: { http: HttpSetup }) {
+  public async setup({ http, uiSettings }: { http: HttpSetup; uiSettings: IUiSettingsClient }) {
+    // If workspace was disabled while opening a workspace url, navigate to basePath
+    if (uiSettings.get('workspace:enabled') === false) {
+      const workspaceId = getWorkspaceIdFromUrl(window.location.href);
+      if (workspaceId) {
+        window.location.href = http.basePath.getBasePath();
+      }
+    }
+
     this.client = new WorkspacesClient(http);
     return {
       client: this.client,

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -263,6 +263,7 @@ export class Server {
     });
     await this.workspaces.start({
       savedObjects: savedObjectsStart,
+      uiSettings: uiSettingsStart,
     });
 
     this.coreStart = {

--- a/src/core/server/ui_settings/settings/index.test.ts
+++ b/src/core/server/ui_settings/settings/index.test.ts
@@ -36,6 +36,7 @@ import { getNotificationsSettings } from './notifications';
 import { getThemeSettings } from './theme';
 import { getCoreSettings } from './index';
 import { getStateSettings } from './state';
+import { getWorkspaceSettings } from './workspace';
 
 describe('getCoreSettings', () => {
   it('should not have setting overlaps', () => {
@@ -48,6 +49,7 @@ describe('getCoreSettings', () => {
       getNotificationsSettings(),
       getThemeSettings(),
       getStateSettings(),
+      getWorkspaceSettings(),
     ].reduce((sum, settings) => sum + Object.keys(settings).length, 0);
 
     expect(coreSettingsLength).toBe(summedLength);

--- a/src/core/server/ui_settings/settings/index.ts
+++ b/src/core/server/ui_settings/settings/index.ts
@@ -36,6 +36,7 @@ import { getNavigationSettings } from './navigation';
 import { getNotificationsSettings } from './notifications';
 import { getThemeSettings } from './theme';
 import { getStateSettings } from './state';
+import { getWorkspaceSettings } from './workspace';
 
 export const getCoreSettings = (): Record<string, UiSettingsParams> => {
   return {
@@ -46,5 +47,6 @@ export const getCoreSettings = (): Record<string, UiSettingsParams> => {
     ...getNotificationsSettings(),
     ...getThemeSettings(),
     ...getStateSettings(),
+    ...getWorkspaceSettings(),
   };
 };

--- a/src/core/server/ui_settings/settings/workspace.ts
+++ b/src/core/server/ui_settings/settings/workspace.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import { i18n } from '@osd/i18n';
+import { UiSettingsParams } from '../../../types';
+
+export const getWorkspaceSettings = (): Record<string, UiSettingsParams> => {
+  return {
+    'workspace:enabled': {
+      name: i18n.translate('core.ui_settings.params.workspace.enableWorkspaceTitle', {
+        defaultMessage: 'Enable Workspace',
+      }),
+      value: false,
+      requiresPageReload: true,
+      description: i18n.translate('core.ui_settings.params.workspace.enableWorkspaceTitle', {
+        defaultMessage: 'Enable or disable OpenSearch Dashboards Workspace',
+      }),
+      category: ['workspace'],
+      schema: schema.boolean(),
+    },
+  };
+};

--- a/src/plugins/workspace/public/containers/workspace_dropdown_list/workspace_dropdown_list.tsx
+++ b/src/plugins/workspace/public/containers/workspace_dropdown_list/workspace_dropdown_list.tsx
@@ -7,14 +7,15 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 
 import { EuiButton, EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
-import { CoreStart, WorkspaceAttribute } from '../../../../../core/public';
+import { ApplicationStart, WorkspaceAttribute, WorkspacesStart } from '../../../../../core/public';
 import { WORKSPACE_APP_ID, PATHS } from '../../../common/constants';
 import { switchWorkspace } from '../../components/utils/workspace';
 
 type WorkspaceOption = EuiComboBoxOptionOption<WorkspaceAttribute>;
 
 interface WorkspaceDropdownListProps {
-  coreStart: CoreStart;
+  workspaces: WorkspacesStart;
+  application: ApplicationStart;
 }
 
 function workspaceToOption(workspace: WorkspaceAttribute): WorkspaceOption {
@@ -27,10 +28,8 @@ export function getErrorMessage(err: any) {
 }
 
 export function WorkspaceDropdownList(props: WorkspaceDropdownListProps) {
-  const { coreStart } = props;
-
-  const workspaceList = useObservable(coreStart.workspaces.client.workspaceList$, []);
-  const currentWorkspace = useObservable(coreStart.workspaces.client.currentWorkspace$, null);
+  const workspaceList = useObservable(props.workspaces.client.workspaceList$, []);
+  const currentWorkspace = useObservable(props.workspaces.client.currentWorkspace$, null);
 
   const [loading, setLoading] = useState(false);
   const [workspaceOptions, setWorkspaceOptions] = useState([] as WorkspaceOption[]);
@@ -58,14 +57,14 @@ export function WorkspaceDropdownList(props: WorkspaceDropdownListProps) {
       /** switch the workspace */
       setLoading(true);
       const id = workspaceOption[0].key!;
-      switchWorkspace(coreStart, id);
+      switchWorkspace({ workspaces: props.workspaces, application: props.application }, id);
       setLoading(false);
     },
-    [coreStart]
+    [props.application, props.workspaces]
   );
 
   const onCreateWorkspaceClick = () => {
-    coreStart.application.navigateToApp(WORKSPACE_APP_ID, { path: PATHS.create });
+    props.application.navigateToApp(WORKSPACE_APP_ID, { path: PATHS.create });
   };
 
   useEffect(() => {

--- a/src/plugins/workspace/public/mount.tsx
+++ b/src/plugins/workspace/public/mount.tsx
@@ -5,14 +5,25 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CoreStart } from '../../../core/public';
+import { ApplicationStart, ChromeStart, WorkspacesStart } from '../../../core/public';
 import { WorkspaceDropdownList } from './containers/workspace_dropdown_list';
 
-export const mountDropdownList = (core: CoreStart) => {
-  core.chrome.navControls.registerLeft({
+export const mountDropdownList = ({
+  application,
+  workspaces,
+  chrome,
+}: {
+  application: ApplicationStart;
+  workspaces: WorkspacesStart;
+  chrome: ChromeStart;
+}) => {
+  chrome.navControls.registerLeft({
     order: 0,
     mount: (element) => {
-      ReactDOM.render(<WorkspaceDropdownList coreStart={core} />, element);
+      ReactDOM.render(
+        <WorkspaceDropdownList workspaces={workspaces} application={application} />,
+        element
+      );
       return () => {
         ReactDOM.unmountComponentAtNode(element);
       };

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -16,7 +16,8 @@ import { mountDropdownList } from './mount';
 import { getWorkspaceIdFromUrl } from '../../../core/public/utils';
 
 export class WorkspacesPlugin implements Plugin<{}, {}> {
-  private core?: CoreSetup;
+  private coreSetup?: CoreSetup;
+  private coreStart?: CoreStart;
   private getWorkspaceIdFromURL(): string | null {
     return getWorkspaceIdFromUrl(window.location.href);
   }
@@ -25,20 +26,25 @@ export class WorkspacesPlugin implements Plugin<{}, {}> {
     /**
      * Patch workspace id into path
      */
-    newUrl.pathname = this.core?.http.basePath.remove(newUrl.pathname) || '';
+    newUrl.pathname = this.coreSetup?.http.basePath.remove(newUrl.pathname) || '';
     if (workspaceId) {
-      newUrl.pathname = `${this.core?.http.basePath.serverBasePath || ''}/w/${workspaceId}${
+      newUrl.pathname = `${this.coreSetup?.http.basePath.serverBasePath || ''}/w/${workspaceId}${
         newUrl.pathname
       }`;
     } else {
-      newUrl.pathname = `${this.core?.http.basePath.serverBasePath || ''}${newUrl.pathname}`;
+      newUrl.pathname = `${this.coreSetup?.http.basePath.serverBasePath || ''}${newUrl.pathname}`;
     }
 
     return newUrl.toString();
   };
   public async setup(core: CoreSetup) {
-    this.core = core;
-    this.core?.workspaces.setFormatUrlWithWorkspaceId((url, id) => this.getPatchedUrl(url, id));
+    // If workspace feature is disabled, it will not load the workspace plugin
+    if (core.uiSettings.get('workspace:enabled') === false) {
+      return {};
+    }
+
+    this.coreSetup = core;
+    core.workspaces.setFormatUrlWithWorkspaceId((url, id) => this.getPatchedUrl(url, id));
     /**
      * Retrieve workspace id from url
      */
@@ -78,18 +84,27 @@ export class WorkspacesPlugin implements Plugin<{}, {}> {
     return {};
   }
 
-  private async _changeSavedObjectCurrentWorkspace() {
-    const startServices = await this.core?.getStartServices();
-    if (startServices) {
-      const coreStart = startServices[0];
-      coreStart.workspaces.client.currentWorkspaceId$.subscribe((currentWorkspaceId) => {
-        coreStart.savedObjects.client.setCurrentWorkspace(currentWorkspaceId);
+  private _changeSavedObjectCurrentWorkspace() {
+    if (this.coreStart) {
+      this.coreStart.workspaces.client.currentWorkspaceId$.subscribe((currentWorkspaceId) => {
+        this.coreStart?.savedObjects.client.setCurrentWorkspace(currentWorkspaceId);
       });
     }
   }
 
   public start(core: CoreStart) {
-    mountDropdownList(core);
+    // If workspace feature is disabled, it will not load the workspace plugin
+    if (core.uiSettings.get('workspace:enabled') === false) {
+      return {};
+    }
+
+    this.coreStart = core;
+
+    mountDropdownList({
+      application: core.application,
+      workspaces: core.workspaces,
+      chrome: core.chrome,
+    });
     this._changeSavedObjectCurrentWorkspace();
     return {};
   }


### PR DESCRIPTION
### Description
This PR adds a `workspace` configuration section in advance settings which allows user to turn on/off workspace feature.


### Issues Resolved
None

## Screenshot
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/486382/cee0e8ed-6bab-4f92-984e-f9d1b5ea103f)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
