### PR TITLE
Refactor: Assign default value for filtered nav links

### DIFF
--- a/src/core/public/chrome/nav_links/nav_links_service.ts
+++ b/src/core/public/chrome/nav_links/nav_links_service.ts
@@ -167,7 +167,12 @@ export class NavLinksService {
       },
 
       getFilteredNavLinks$: () => {
-        return this.filteredNavLinks$.pipe(map(sortChromeNavLinks), takeUntil(this.stop$));
+        return combineLatest([navLinks$, this.filteredNavLinks$]).pipe(
+          map(([navLinks, filteredNavLinks]) =>
+            filteredNavLinks.size ? sortChromeNavLinks(filteredNavLinks) : sortNavLinks(navLinks)
+          ),
+          takeUntil(this.stop$)
+        );
       },
 
       get(id: string) {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -153,107 +153,95 @@ export class WorkspacesPlugin implements Plugin<{}, {}, WorkspacesPluginSetupDep
     return allNavLinks.filter((item) => features.includes(item.id));
   }
 
-  private filterNavLinks(core: CoreStart, workspaceEnabled: boolean) {
+  private filterNavLinks(core: CoreStart) {
     const navLinksService = core.chrome.navLinks;
     const chromeNavLinks$ = navLinksService.getNavLinks$();
-    if (workspaceEnabled) {
-      const workspaceList$ = core.workspaces.client.workspaceList$;
-      const currentWorkspace$ = core.workspaces.client.currentWorkspace$;
-      combineLatest([
-        workspaceList$,
-        chromeNavLinks$.pipe(map(this.changeCategoryNameByWorkspaceFeatureFlag)),
-        currentWorkspace$,
-      ]).subscribe(([workspaceList, chromeNavLinks, currentWorkspace]) => {
-        const filteredNavLinks = new Map<string, ChromeNavLink>();
-        chromeNavLinks = this.filterByWorkspace(currentWorkspace, chromeNavLinks);
-        chromeNavLinks.forEach((chromeNavLink) => {
-          if (chromeNavLink.id === 'home') {
-            // set hidden, icon and order for home nav link
-            const homeNavLink: ChromeNavLink = {
-              ...chromeNavLink,
-              hidden: currentWorkspace !== null,
-              euiIconType: 'logoOpenSearch',
-              order: 0,
-            };
-            filteredNavLinks.set(chromeNavLink.id, homeNavLink);
-          } else {
-            filteredNavLinks.set(chromeNavLink.id, chromeNavLink);
-          }
-        });
-        workspaceList
-          .filter((value, index) => !currentWorkspace && index < 5)
-          .map((workspace) =>
-            this.workspaceToChromeNavLink(workspace, core.workspaces, core.application)
-          )
-          .forEach((workspaceNavLink) =>
-            filteredNavLinks.set(workspaceNavLink.id, workspaceNavLink)
-          );
-        // See more
-        const seeMoreId = WORKSPACE_APP_ID + PATHS.list;
-        const seeMoreUrl = WORKSPACE_APP_ID + PATHS.list;
-        const seeMoreNavLink: ChromeNavLink = {
-          id: seeMoreId,
-          title: i18n.translate('core.ui.workspaceNavList.seeMore', {
-            defaultMessage: 'SEE MORE',
-          }),
-          hidden: currentWorkspace !== null,
-          disabled: false,
-          baseUrl: seeMoreUrl,
-          href: seeMoreUrl,
-          category: WORKSPACE_NAV_CATEGORY,
-        };
-        filteredNavLinks.set(seeMoreId, seeMoreNavLink);
-        // Admin
-        const adminId = 'admin';
-        const adminUrl = '/app/admin';
-        const adminNavLink: ChromeNavLink = {
-          id: adminId,
-          title: i18n.translate('core.ui.workspaceNavList.admin', {
-            defaultMessage: 'Admin',
-          }),
-          hidden: currentWorkspace !== null,
-          disabled: true,
-          baseUrl: adminUrl,
-          href: adminUrl,
-          euiIconType: 'managementApp',
-          order: 9000,
-        };
-        filteredNavLinks.set(adminId, adminNavLink);
-        // Overview only inside workspace
-        if (currentWorkspace) {
-          const overviewId = WORKSPACE_APP_ID + PATHS.update;
-          const overviewUrl = core.workspaces.formatUrlWithWorkspaceId(
-            core.application.getUrlForApp(WORKSPACE_APP_ID, {
-              path: PATHS.update,
-              absolute: true,
-            }),
-            currentWorkspace.id
-          );
-          const overviewNavLink: ChromeNavLink = {
-            id: overviewId,
-            title: i18n.translate('core.ui.workspaceNavList.overview', {
-              defaultMessage: 'Overview',
-            }),
-            hidden: false,
-            disabled: false,
-            baseUrl: overviewUrl,
-            href: overviewUrl,
-            euiIconType: 'grid',
+    const workspaceList$ = core.workspaces.client.workspaceList$;
+    const currentWorkspace$ = core.workspaces.client.currentWorkspace$;
+    combineLatest([
+      workspaceList$,
+      chromeNavLinks$.pipe(map(this.changeCategoryNameByWorkspaceFeatureFlag)),
+      currentWorkspace$,
+    ]).subscribe(([workspaceList, chromeNavLinks, currentWorkspace]) => {
+      const filteredNavLinks = new Map<string, ChromeNavLink>();
+      chromeNavLinks = this.filterByWorkspace(currentWorkspace, chromeNavLinks);
+      chromeNavLinks.forEach((chromeNavLink) => {
+        if (chromeNavLink.id === 'home') {
+          // set hidden, icon and order for home nav link
+          const homeNavLink: ChromeNavLink = {
+            ...chromeNavLink,
+            hidden: currentWorkspace !== null,
+            euiIconType: 'logoOpenSearch',
             order: 0,
           };
-          filteredNavLinks.set(overviewId, overviewNavLink);
+          filteredNavLinks.set(chromeNavLink.id, homeNavLink);
+        } else {
+          filteredNavLinks.set(chromeNavLink.id, chromeNavLink);
         }
-        navLinksService.setFilteredNavLinks(filteredNavLinks);
       });
-    } else {
-      chromeNavLinks$.subscribe((chromeNavLinks) => {
-        const filteredNavLinks = new Map<string, ChromeNavLink>();
-        chromeNavLinks.forEach((chromeNavLink) =>
-          filteredNavLinks.set(chromeNavLink.id, chromeNavLink)
+      workspaceList
+        .filter((value, index) => !currentWorkspace && index < 5)
+        .map((workspace) =>
+          this.workspaceToChromeNavLink(workspace, core.workspaces, core.application)
+        )
+        .forEach((workspaceNavLink) => filteredNavLinks.set(workspaceNavLink.id, workspaceNavLink));
+      // See more
+      const seeMoreId = WORKSPACE_APP_ID + PATHS.list;
+      const seeMoreUrl = WORKSPACE_APP_ID + PATHS.list;
+      const seeMoreNavLink: ChromeNavLink = {
+        id: seeMoreId,
+        title: i18n.translate('core.ui.workspaceNavList.seeMore', {
+          defaultMessage: 'SEE MORE',
+        }),
+        hidden: currentWorkspace !== null,
+        disabled: false,
+        baseUrl: seeMoreUrl,
+        href: seeMoreUrl,
+        category: WORKSPACE_NAV_CATEGORY,
+      };
+      filteredNavLinks.set(seeMoreId, seeMoreNavLink);
+      // Admin
+      const adminId = 'admin';
+      const adminUrl = '/app/admin';
+      const adminNavLink: ChromeNavLink = {
+        id: adminId,
+        title: i18n.translate('core.ui.workspaceNavList.admin', {
+          defaultMessage: 'Admin',
+        }),
+        hidden: currentWorkspace !== null,
+        disabled: true,
+        baseUrl: adminUrl,
+        href: adminUrl,
+        euiIconType: 'managementApp',
+        order: 9000,
+      };
+      filteredNavLinks.set(adminId, adminNavLink);
+      // Overview only inside workspace
+      if (currentWorkspace) {
+        const overviewId = WORKSPACE_APP_ID + PATHS.update;
+        const overviewUrl = core.workspaces.formatUrlWithWorkspaceId(
+          core.application.getUrlForApp(WORKSPACE_APP_ID, {
+            path: PATHS.update,
+            absolute: true,
+          }),
+          currentWorkspace.id
         );
-        navLinksService.setFilteredNavLinks(filteredNavLinks);
-      });
-    }
+        const overviewNavLink: ChromeNavLink = {
+          id: overviewId,
+          title: i18n.translate('core.ui.workspaceNavList.overview', {
+            defaultMessage: 'Overview',
+          }),
+          hidden: false,
+          disabled: false,
+          baseUrl: overviewUrl,
+          href: overviewUrl,
+          euiIconType: 'grid',
+          order: 0,
+        };
+        filteredNavLinks.set(overviewId, overviewNavLink);
+      }
+      navLinksService.setFilteredNavLinks(filteredNavLinks);
+    });
   }
 
   /**
@@ -281,8 +269,6 @@ export class WorkspacesPlugin implements Plugin<{}, {}, WorkspacesPluginSetupDep
   public start(core: CoreStart) {
     // If workspace feature is disabled, it will not load the workspace plugin
     if (core.uiSettings.get('workspace:enabled') === false) {
-      // set default value for filtered nav links
-      this.filterNavLinks(core, false);
       return {};
     }
 
@@ -295,7 +281,7 @@ export class WorkspacesPlugin implements Plugin<{}, {}, WorkspacesPluginSetupDep
     });
     this.currentWorkspaceSubscription = this._changeSavedObjectCurrentWorkspace();
     if (core) {
-      this.filterNavLinks(core, true);
+      this.filterNavLinks(core);
     }
     return {};
   }

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -179,45 +179,8 @@ export class WorkspacesPlugin implements Plugin<{}, {}, WorkspacesPluginSetupDep
           filteredNavLinks.set(chromeNavLink.id, chromeNavLink);
         }
       });
-      workspaceList
-        .filter((value, index) => !currentWorkspace && index < 5)
-        .map((workspace) =>
-          this.workspaceToChromeNavLink(workspace, core.workspaces, core.application)
-        )
-        .forEach((workspaceNavLink) => filteredNavLinks.set(workspaceNavLink.id, workspaceNavLink));
-      // See more
-      const seeMoreId = WORKSPACE_APP_ID + PATHS.list;
-      const seeMoreUrl = WORKSPACE_APP_ID + PATHS.list;
-      const seeMoreNavLink: ChromeNavLink = {
-        id: seeMoreId,
-        title: i18n.translate('core.ui.workspaceNavList.seeMore', {
-          defaultMessage: 'SEE MORE',
-        }),
-        hidden: currentWorkspace !== null,
-        disabled: false,
-        baseUrl: seeMoreUrl,
-        href: seeMoreUrl,
-        category: WORKSPACE_NAV_CATEGORY,
-      };
-      filteredNavLinks.set(seeMoreId, seeMoreNavLink);
-      // Admin
-      const adminId = 'admin';
-      const adminUrl = '/app/admin';
-      const adminNavLink: ChromeNavLink = {
-        id: adminId,
-        title: i18n.translate('core.ui.workspaceNavList.admin', {
-          defaultMessage: 'Admin',
-        }),
-        hidden: currentWorkspace !== null,
-        disabled: true,
-        baseUrl: adminUrl,
-        href: adminUrl,
-        euiIconType: 'managementApp',
-        order: 9000,
-      };
-      filteredNavLinks.set(adminId, adminNavLink);
-      // Overview only inside workspace
       if (currentWorkspace) {
+        // Overview only inside workspace
         const overviewId = WORKSPACE_APP_ID + PATHS.update;
         const overviewUrl = core.workspaces.formatUrlWithWorkspaceId(
           core.application.getUrlForApp(WORKSPACE_APP_ID, {
@@ -239,6 +202,46 @@ export class WorkspacesPlugin implements Plugin<{}, {}, WorkspacesPluginSetupDep
           order: 0,
         };
         filteredNavLinks.set(overviewId, overviewNavLink);
+      } else {
+        workspaceList
+          .filter((workspace, index) => index < 5)
+          .map((workspace) =>
+            this.workspaceToChromeNavLink(workspace, core.workspaces, core.application)
+          )
+          .forEach((workspaceNavLink) =>
+            filteredNavLinks.set(workspaceNavLink.id, workspaceNavLink)
+          );
+        // See more
+        const seeMoreId = WORKSPACE_APP_ID + PATHS.list;
+        const seeMoreUrl = WORKSPACE_APP_ID + PATHS.list;
+        const seeMoreNavLink: ChromeNavLink = {
+          id: seeMoreId,
+          title: i18n.translate('core.ui.workspaceNavList.seeMore', {
+            defaultMessage: 'SEE MORE',
+          }),
+          hidden: false,
+          disabled: false,
+          baseUrl: seeMoreUrl,
+          href: seeMoreUrl,
+          category: WORKSPACE_NAV_CATEGORY,
+        };
+        filteredNavLinks.set(seeMoreId, seeMoreNavLink);
+        // Admin
+        const adminId = 'admin';
+        const adminUrl = '/app/admin';
+        const adminNavLink: ChromeNavLink = {
+          id: adminId,
+          title: i18n.translate('core.ui.workspaceNavList.admin', {
+            defaultMessage: 'Admin',
+          }),
+          hidden: false,
+          disabled: true,
+          baseUrl: adminUrl,
+          href: adminUrl,
+          euiIconType: 'managementApp',
+          order: 9000,
+        };
+        filteredNavLinks.set(adminId, adminNavLink);
       }
       navLinksService.setFilteredNavLinks(filteredNavLinks);
     });


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Refactor the default value setting from workspace plugin.ts to nav_link_service.ts. Specifically, if `filteredNavLinks` is not empty, we can directly return it. Otherwise, we return the default value `navLinks`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
