### PR TITLE
refactor: in left menu, move recently viewed from top to middle

### DIFF
--- a/src/core/public/chrome/nav_links/nav_link.ts
+++ b/src/core/public/chrome/nav_links/nav_link.ts
@@ -93,8 +93,10 @@ export interface ChromeNavLink {
    * Disables a link from being clickable.
    *
    * @internalRemarks
-   * This is only used by the ML and Graph plugins currently. They use this field
+   * This is used by the ML and Graph plugins. They use this field
    * to disable the nav link when the license is expired.
+   * This is also used by recently visited category in left menu
+   * to disable "No recently visited items".
    */
   readonly disabled?: boolean;
 

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -48,7 +48,7 @@ import { AppCategory } from '../../../../types';
 import { InternalApplicationStart } from '../../../application';
 import { HttpStart } from '../../../http';
 import { OnIsLockedUpdate } from './';
-import { createEuiListItem, createRecentChromeNavLink } from './nav_link';
+import { createEuiListItem, createRecentChromeNavLink, emptyRecentlyVisited } from './nav_link';
 import { ChromeBranding } from '../../chrome_service';
 import { CollapsibleNavHeader } from './collapsible_nav_header';
 
@@ -148,9 +148,13 @@ export function CollapsibleNav({
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
   const recentlyAccessed = useObservable(observables.recentlyAccessed$, []);
-  navLinks.push(
-    ...recentlyAccessed.map((link) => createRecentChromeNavLink(link, navLinks, basePath))
-  );
+  if (recentlyAccessed.length) {
+    navLinks.push(
+      ...recentlyAccessed.map((link) => createRecentChromeNavLink(link, navLinks, basePath))
+    );
+  } else {
+    navLinks.push(emptyRecentlyVisited);
+  }
   const appId = useObservable(observables.appId$, '');
   const lockRef = useRef<HTMLButtonElement>(null);
   const groupedNavLinks = groupBy(navLinks, (link) => link?.category?.id);

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -52,12 +52,12 @@ import {
   createEuiListItem,
   createRecentChromeNavLink,
   emptyRecentlyVisited,
-  ChromeOrRecentNavLink,
+  CollapsibleNavLink,
 } from './nav_link';
 import { ChromeBranding } from '../../chrome_service';
 import { CollapsibleNavHeader } from './collapsible_nav_header';
 
-function getAllCategories(allCategorizedLinks: Record<string, ChromeOrRecentNavLink[]>) {
+function getAllCategories(allCategorizedLinks: Record<string, CollapsibleNavLink[]>) {
   const allCategories = {} as Record<string, AppCategory | undefined>;
 
   for (const [key, value] of Object.entries(allCategorizedLinks)) {
@@ -68,7 +68,7 @@ function getAllCategories(allCategorizedLinks: Record<string, ChromeOrRecentNavL
 }
 
 function getOrderedCategories(
-  mainCategories: Record<string, ChromeOrRecentNavLink[]>,
+  mainCategories: Record<string, CollapsibleNavLink[]>,
   categoryDictionary: ReturnType<typeof getAllCategories>
 ) {
   return sortBy(
@@ -79,9 +79,9 @@ function getOrderedCategories(
 
 function getMergedNavLinks(
   orderedCategories: string[],
-  uncategorizedLinks: ChromeOrRecentNavLink[],
+  uncategorizedLinks: CollapsibleNavLink[],
   categoryDictionary: ReturnType<typeof getAllCategories>
-): Array<string | ChromeOrRecentNavLink> {
+): Array<string | CollapsibleNavLink> {
   const uncategorizedLinksWithOrder = sortBy(
     uncategorizedLinks.filter((link) => link.order !== null),
     'order'
@@ -153,7 +153,7 @@ export function CollapsibleNav({
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
   const recentlyAccessed = useObservable(observables.recentlyAccessed$, []);
-  const allNavLinks: ChromeOrRecentNavLink[] = [...navLinks];
+  const allNavLinks: CollapsibleNavLink[] = [...navLinks];
   if (recentlyAccessed.length) {
     allNavLinks.push(
       ...recentlyAccessed.map((link) => createRecentChromeNavLink(link, navLinks, basePath))
@@ -173,7 +173,7 @@ export function CollapsibleNav({
     categoryDictionary
   );
 
-  const readyForEUI = (link: ChromeOrRecentNavLink, needsIcon: boolean = false) => {
+  const readyForEUI = (link: CollapsibleNavLink, needsIcon: boolean = false) => {
     return createEuiListItem({
       link,
       appId,

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -38,8 +38,9 @@ import { relativeToAbsolute } from '../../nav_links/to_nav_link';
 export const isModifiedOrPrevented = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
   event.metaKey || event.altKey || event.ctrlKey || event.shiftKey || event.defaultPrevented;
 
+export type ChromeOrRecentNavLink = ChromeNavLink | RecentNavLink;
 interface Props {
-  link: ChromeNavLink;
+  link: ChromeNavLink | RecentNavLink;
   appId?: string;
   basePath?: HttpStart['basePath'];
   dataTestSubj: string;
@@ -90,6 +91,8 @@ export function createEuiListItem({
   };
 }
 
+export type RecentNavLink = Omit<ChromeNavLink, 'baseUrl'>;
+
 const recentlyVisitedCategory: AppCategory = {
   id: 'recentlyVisited',
   label: i18n.translate('core.ui.recentlyVisited.label', {
@@ -113,7 +116,7 @@ export function createRecentChromeNavLink(
   recentLink: ChromeRecentlyAccessedHistoryItem,
   navLinks: ChromeNavLink[],
   basePath: HttpStart['basePath']
-): ChromeNavLink {
+): RecentNavLink {
   const { link, label } = recentLink;
   const href = relativeToAbsolute(basePath.prepend(link));
   const navLink = navLinks.find((nl) => href.startsWith(nl.baseUrl));
@@ -129,10 +132,8 @@ export function createRecentChromeNavLink(
     });
   }
 
-  // As RecentChromeNavLink is only used in function createEuiListItem, value for baseUrl does not affect
   return {
     href,
-    baseUrl: href,
     id: recentLink.id,
     externalLink: true,
     category: recentlyVisitedCategory,
@@ -141,13 +142,12 @@ export function createRecentChromeNavLink(
 }
 
 // As emptyRecentlyVisited is disabled, values for id, href and baseUrl does not affect
-export const emptyRecentlyVisited: ChromeNavLink = {
-  href: '',
-  baseUrl: '',
+export const emptyRecentlyVisited: RecentNavLink = {
   id: '',
+  href: '',
   disabled: true,
   category: recentlyVisitedCategory,
-  title: i18n.translate('core.ui.EmptyRecentlyVisitied', {
+  title: i18n.translate('core.ui.EmptyRecentlyVisited', {
     defaultMessage: 'No recently visited items',
   }),
 };

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -31,9 +31,8 @@
 import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
-import { ChromeNavLink, ChromeRecentlyAccessedHistoryItem, CoreStart } from '../../..';
+import { AppCategory, ChromeNavLink, ChromeRecentlyAccessedHistoryItem, CoreStart } from '../../..';
 import { HttpStart } from '../../../http';
-import { InternalApplicationStart } from '../../../application/types';
 import { relativeToAbsolute } from '../../nav_links/to_nav_link';
 
 export const isModifiedOrPrevented = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
@@ -46,7 +45,6 @@ interface Props {
   dataTestSubj: string;
   onClick?: Function;
   navigateToApp: CoreStart['application']['navigateToApp'];
-  externalLink?: boolean;
 }
 
 // TODO #64541
@@ -91,14 +89,14 @@ export function createEuiListItem({
   };
 }
 
-export interface RecentNavLink {
-  href: string;
-  label: string;
-  title: string;
-  'aria-label': string;
-  iconType?: string;
-  onClick: React.MouseEventHandler;
-}
+const recentlyVisitedCategory: AppCategory = {
+  id: 'recentlyVisited',
+  label: i18n.translate('core.ui.recentlyVisited.label', {
+    defaultMessage: 'Recently Visited',
+  }),
+  order: 0,
+  euiIconType: 'clock',
+};
 
 /**
  * Add saved object type info to recently links
@@ -110,12 +108,11 @@ export interface RecentNavLink {
  * @param navLinks
  * @param basePath
  */
-export function createRecentNavLink(
+export function createRecentChromeNavLink(
   recentLink: ChromeRecentlyAccessedHistoryItem,
   navLinks: ChromeNavLink[],
-  basePath: HttpStart['basePath'],
-  navigateToUrl: InternalApplicationStart['navigateToUrl']
-): RecentNavLink {
+  basePath: HttpStart['basePath']
+): ChromeNavLink {
   const { link, label } = recentLink;
   const href = relativeToAbsolute(basePath.prepend(link));
   const navLink = navLinks.find((nl) => href.startsWith(nl.baseUrl));
@@ -133,16 +130,10 @@ export function createRecentNavLink(
 
   return {
     href,
-    label,
+    baseUrl: href,
+    id: recentLink.id,
+    externalLink: true,
+    category: recentlyVisitedCategory,
     title: titleAndAriaLabel,
-    'aria-label': titleAndAriaLabel,
-    iconType: navLink?.euiIconType,
-    /* Use href and onClick to support "open in new tab" and SPA navigation in the same link */
-    onClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-      if (event.button === 0 && !isModifiedOrPrevented(event)) {
-        event.preventDefault();
-        navigateToUrl(href);
-      }
-    },
   };
 }

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -129,6 +129,7 @@ export function createRecentChromeNavLink(
     });
   }
 
+  // As RecentChromeNavLink is only used in function createEuiListItem, value for baseUrl does not affect
   return {
     href,
     baseUrl: href,
@@ -138,3 +139,15 @@ export function createRecentChromeNavLink(
     title: titleAndAriaLabel,
   };
 }
+
+// As this link is disabled, values for id, href and baseUrl does not affect
+export const emptyRecentlyVisited: ChromeNavLink = {
+  href: '',
+  baseUrl: '',
+  id: '',
+  disabled: true,
+  category: recentlyVisitedCategory,
+  title: i18n.translate('core.ui.EmptyRecentlyVisitied', {
+    defaultMessage: 'No recently visited items',
+  }),
+};

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -140,7 +140,7 @@ export function createRecentChromeNavLink(
   };
 }
 
-// As this link is disabled, values for id, href and baseUrl does not affect
+// As emptyRecentlyVisited is disabled, values for id, href and baseUrl does not affect
 export const emptyRecentlyVisited: ChromeNavLink = {
   href: '',
   baseUrl: '',

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -71,6 +71,7 @@ export function createEuiListItem({
       }
 
       if (
+        !link.externalLink && // ignore external links
         event.button === 0 && // ignore everything but left clicks
         !isModifiedOrPrevented(event)
       ) {

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -38,7 +38,7 @@ import { relativeToAbsolute } from '../../nav_links/to_nav_link';
 export const isModifiedOrPrevented = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
   event.metaKey || event.altKey || event.ctrlKey || event.shiftKey || event.defaultPrevented;
 
-export type ChromeOrRecentNavLink = ChromeNavLink | RecentNavLink;
+export type CollapsibleNavLink = ChromeNavLink | RecentNavLink;
 interface Props {
   link: ChromeNavLink | RecentNavLink;
   appId?: string;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

The category name has changed from "recently viewed" to "recently visited". We need to confirm with UX team whether to render this category when there is no recently accessed items.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/761c0f21-8443-4c89-84cb-9a40c5ab480a)

![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/807f90a3-b40d-4351-bb7d-f2b998446590)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
