### PR TITLE
fix: redirect to home only when delete and exit workspace successfully

### DIFF
--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -55,5 +55,6 @@ export class WorkspaceService implements CoreService<WorkspaceSetup, WorkspaceSt
     this.currentWorkspace$.unsubscribe();
     this.currentWorkspaceId$.unsubscribe();
     this.workspaceList$.unsubscribe();
+    this.workspaceEnabled$.unsubscribe();
   }
 }

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -117,6 +117,16 @@ export const WorkspaceUpdater = () => {
             defaultMessage: 'Delete workspace successfully',
           }),
         });
+        if (http && application) {
+          const homeUrl = application.getUrlForApp('home', {
+            path: '/',
+            absolute: false,
+          });
+          const targetUrl = http.basePath.prepend(http.basePath.remove(homeUrl), {
+            withoutWorkspace: true,
+          });
+          await application.navigateToUrl(targetUrl);
+        }
       } else {
         notifications?.toasts.addDanger({
           title: i18n.translate('workspace.delete.failed', {
@@ -127,16 +137,6 @@ export const WorkspaceUpdater = () => {
       }
     }
     setDeleteWorkspaceModalVisible(false);
-    if (http && application) {
-      const homeUrl = application.getUrlForApp('home', {
-        path: '/',
-        absolute: false,
-      });
-      const targetUrl = http.basePath.prepend(http.basePath.remove(homeUrl), {
-        withoutWorkspace: true,
-      });
-      await application.navigateToUrl(targetUrl);
-    }
   };
 
   const exitWorkspace = async () => {
@@ -152,7 +152,18 @@ export const WorkspaceUpdater = () => {
       });
       return;
     }
-    if (!result?.success) {
+    if (result.success) {
+      if (http && application) {
+        const homeUrl = application.getUrlForApp('home', {
+          path: '/',
+          absolute: false,
+        });
+        const targetUrl = http.basePath.prepend(http.basePath.remove(homeUrl), {
+          withoutWorkspace: true,
+        });
+        await application.navigateToUrl(targetUrl);
+      }
+    } else {
       notifications?.toasts.addDanger({
         title: i18n.translate('workspace.exit.failed', {
           defaultMessage: 'Failed to exit workspace',
@@ -160,16 +171,6 @@ export const WorkspaceUpdater = () => {
         text: result?.error,
       });
       return;
-    }
-    if (http && application) {
-      const homeUrl = application.getUrlForApp('home', {
-        path: '/',
-        absolute: false,
-      });
-      const targetUrl = http.basePath.prepend(http.basePath.remove(homeUrl), {
-        withoutWorkspace: true,
-      });
-      await application.navigateToUrl(targetUrl);
     }
   };
 

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -117,6 +117,7 @@ export const WorkspaceUpdater = () => {
             defaultMessage: 'Delete workspace successfully',
           }),
         });
+        setDeleteWorkspaceModalVisible(false);
         if (http && application) {
           const homeUrl = application.getUrlForApp('home', {
             path: '/',
@@ -136,7 +137,6 @@ export const WorkspaceUpdater = () => {
         });
       }
     }
-    setDeleteWorkspaceModalVisible(false);
   };
 
   const exitWorkspace = async () => {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

A navigation bug for delete and exit workspace has been fixed in this PR. With this PR, the user will only navigation to home page when delete and exit workspace successfully. Also, I also fixed a bug for workspace start. The value of `workspaceEnabled$` will unsubscribe when `WorkspaceService` get stopped.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

The error message remains the same:

![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/4b2f4132-d57c-4045-9528-a7fac694fa8f)


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
