### PR TITLE
fix: two "Overview"s under library section

### DIFF
--- a/src/plugins/saved_objects_management/public/constants.ts
+++ b/src/plugins/saved_objects_management/public/constants.ts
@@ -5,9 +5,19 @@
 
 import { i18n } from '@osd/i18n';
 
-export const LIBRARY_OVERVIEW_WORDINGS = i18n.translate('savedObjectsManagement.libraryOverview', {
-  defaultMessage: 'Overview',
-});
+export const ALL_LIBRARY_OBJECTS_WORDINGS = i18n.translate(
+  'savedObjectsManagement.allLibraryObjects',
+  {
+    defaultMessage: 'All library objects',
+  }
+);
+
+export const ALL_LIBRARY_OBJECTS_TITLE_WORDINGS = i18n.translate(
+  'savedObjectsManagement.objectsTable.header.allLibraryObjectsTitle',
+  {
+    defaultMessage: 'Library objects in Analytics',
+  }
+);
 
 export const SAVED_OBJECT_MANAGEMENT_TITLE_WORDINGS = i18n.translate(
   'savedObjectsManagement.objectsTable.header.savedObjectsTitle',

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -57,7 +57,8 @@ import { registerServices } from './register_services';
 import { bootstrap } from './ui_actions_bootstrap';
 import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 import {
-  LIBRARY_OVERVIEW_WORDINGS,
+  ALL_LIBRARY_OBJECTS_TITLE_WORDINGS,
+  ALL_LIBRARY_OBJECTS_WORDINGS,
   SAVED_OBJECT_MANAGEMENT_TITLE_WORDINGS,
   SAVED_QUERIES_WORDINGS,
   SAVED_SEARCHES_WORDINGS,
@@ -135,11 +136,11 @@ export class SavedObjectsManagementPlugin
       id: 'objects_overview',
       appRoute: '/app/objects',
       exactRoute: true,
-      title: LIBRARY_OVERVIEW_WORDINGS,
+      title: ALL_LIBRARY_OBJECTS_WORDINGS,
       order: 10000,
       category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
       mount: mountWrapper({
-        title: SAVED_OBJECT_MANAGEMENT_TITLE_WORDINGS,
+        title: ALL_LIBRARY_OBJECTS_TITLE_WORDINGS,
       }),
     });
 

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -133,7 +133,7 @@ export class SavedObjectsManagementPlugin
      * Register saved objects overview & saved search & saved query here
      */
     core.application.register({
-      id: 'objects_overview',
+      id: 'objects_all',
       appRoute: '/app/objects',
       exactRoute: true,
       title: ALL_LIBRARY_OBJECTS_WORDINGS,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

This PR renames the second **Overview** in library category to **All library objects** and changes title from **Saved Objects** to **Library objects in Analytics**

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

<img width="315" alt="image" src="https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/9857267d-e19e-4cb2-ac14-81bab6a90b32">

<img width="1313" alt="image" src="https://github.com/ruanyl/OpenSearch-Dashboards/assets/32060248/ab91068a-ab39-4881-9cb7-ee7f611c7619">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
