### PR TITLE
added an api to return the saved objects permission control status

### DIFF
--- a/src/core/public/saved_objects/permission_control_client.test.ts
+++ b/src/core/public/saved_objects/permission_control_client.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpServiceMock } from '../http/http_service.mock';
+import { PermissionControlClient } from './permission_control_client';
+
+describe('PermissionControlClient', () => {
+  const http = httpServiceMock.createStartContract();
+  let permissionControlClient: PermissionControlClient;
+
+  beforeEach(() => {
+    permissionControlClient = new PermissionControlClient(http);
+    http.fetch.mockClear();
+  });
+
+  test('returns permission control status', () => {
+    http.fetch.mockResolvedValue({ enabled: true });
+    expect(permissionControlClient.status()).resolves.toEqual({ enabled: true });
+  });
+
+  test('rejects when HTTP call fails', () => {
+    http.fetch.mockRejectedValue(new Error('Request failed'));
+    return expect(permissionControlClient.status()).rejects.toMatchInlineSnapshot(
+      `[Error: Request failed]`
+    );
+  });
+});

--- a/src/core/public/saved_objects/permission_control_client.ts
+++ b/src/core/public/saved_objects/permission_control_client.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PublicMethodsOf } from '@osd/utility-types';
+
+import { HttpSetup } from '../http';
+
+const API_BASE_URL = '/api/saved_objects_permission_control';
+
+export type PermissionControlClientContract = PublicMethodsOf<PermissionControlClient>;
+
+export class PermissionControlClient {
+  private http: HttpSetup;
+
+  constructor(http: HttpSetup) {
+    this.http = http;
+  }
+
+  public async status() {
+    return this.http.fetch(`${API_BASE_URL}/status`);
+  }
+}

--- a/src/core/public/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/public/saved_objects/saved_objects_service.mock.ts
@@ -43,6 +43,9 @@ const createStartContractMock = () => {
       update: jest.fn(),
       setCurrentWorkspace: jest.fn(),
     },
+    permissionControl: {
+      status: jest.fn(),
+    },
   };
   return mock;
 };

--- a/src/core/public/saved_objects/saved_objects_service.ts
+++ b/src/core/public/saved_objects/saved_objects_service.ts
@@ -31,6 +31,10 @@
 import { CoreService } from 'src/core/types';
 import { CoreStart } from 'src/core/public';
 import { SavedObjectsClient, SavedObjectsClientContract } from './saved_objects_client';
+import {
+  PermissionControlClient,
+  PermissionControlClientContract,
+} from './permission_control_client';
 
 /**
  * @public
@@ -38,12 +42,16 @@ import { SavedObjectsClient, SavedObjectsClientContract } from './saved_objects_
 export interface SavedObjectsStart {
   /** {@link SavedObjectsClient} */
   client: SavedObjectsClientContract;
+  permissionControl: PermissionControlClientContract;
 }
 
 export class SavedObjectsService implements CoreService<void, SavedObjectsStart> {
   public async setup() {}
   public async start({ http }: { http: CoreStart['http'] }): Promise<SavedObjectsStart> {
-    return { client: new SavedObjectsClient(http) };
+    return {
+      client: new SavedObjectsClient(http),
+      permissionControl: new PermissionControlClient(http),
+    };
   }
   public async stop() {}
 }

--- a/src/core/server/saved_objects/permission_control/routes/index.ts
+++ b/src/core/server/saved_objects/permission_control/routes/index.ts
@@ -6,6 +6,7 @@
 import { InternalHttpServiceSetup } from '../../../http';
 import { SavedObjectsPermissionControlContract } from '../client';
 import { registerListRoute } from './principals';
+import { registerStatusRoute } from './status';
 import { registerValidateRoute } from './validate';
 
 export function registerPermissionCheckRoutes({
@@ -19,4 +20,5 @@ export function registerPermissionCheckRoutes({
 
   registerValidateRoute(router, permissionControl);
   registerListRoute(router, permissionControl);
+  registerStatusRoute(router, http);
 }

--- a/src/core/server/saved_objects/permission_control/routes/status.ts
+++ b/src/core/server/saved_objects/permission_control/routes/status.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthStatus, InternalHttpServiceSetup, IRouter } from '../../../http';
+
+/**
+ * router to handle permission control settings
+ */
+export const registerStatusRoute = (router: IRouter, http: InternalHttpServiceSetup) => {
+  router.get(
+    {
+      path: '/status',
+      validate: {},
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      // For now, we consider permission control is enabled when `auth` interceptor is registered
+      const enabled = http.auth.get(req).status !== AuthStatus.unknown;
+      return res.ok({ body: { enabled } });
+    })
+  );
+};

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -21,6 +21,7 @@ import {
   SavedObjectsClient,
   WorkspaceAttribute,
   DEFAULT_APP_CATEGORIES,
+  OpenSearchDashboardsRequest,
 } from '../../../core/server';
 import { IWorkspaceDBImpl } from './types';
 import { WorkspaceClientWithSavedObject } from './workspace_client';
@@ -75,6 +76,8 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
       core.savedObjects.permissionControl,
       {
         config$: this.config$,
+        getAuthStatus: (req: OpenSearchDashboardsRequest) =>
+          this.coreStart?.http.auth.get(req).status,
       }
     );
 

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -30,6 +30,7 @@ import {
   WORKSPACE_TYPE,
   ACL,
   WorkspacePermissionMode,
+  AuthStatus,
 } from '../../../../core/server';
 import { ConfigSchema } from '../../config';
 
@@ -478,7 +479,12 @@ export class WorkspaceSavedObjectsClientWrapper {
 
     const isDashboardAdmin = this.isDashboardAdmin(wrapperOptions.request);
 
-    if (isDashboardAdmin) {
+    // if the current request is recognized as dashboard admin it should bypass the permission check
+    // or if there was no auth interceptor registered(auth status is unknown), bypass the permission check
+    if (
+      isDashboardAdmin ||
+      this.options.getAuthStatus(wrapperOptions.request) === AuthStatus.unknown
+    ) {
       return wrapperOptions.client;
     }
 
@@ -504,6 +510,7 @@ export class WorkspaceSavedObjectsClientWrapper {
     private readonly permissionControl: SavedObjectsPermissionControlContract,
     private readonly options: {
       config$: Observable<ConfigSchema>;
+      getAuthStatus: (req: OpenSearchDashboardsRequest) => AuthStatus | undefined;
     }
   ) {
     this.options.config$.subscribe((config) => {


### PR DESCRIPTION
A new API is added to return if the permission control is enabled or not. For now, we consider permission control is enabled if the current OSD server has `auth` interceptor registered.

For OSD server, when `auth` interceptor is not registered, we will consider OSD has no authentication enabled. In such case, bypass saved objects permission check(object level ACL).

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
