### PR TITLE
[Backport workspace-2.9]Refractor: remove `processFindOptions` and `getPermissionQuery` methods declaration in repositoryClient (#142)

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -2015,20 +2015,6 @@ exports[`Header handles visibility and lock changes 1`] = `
               "borders": "none",
               "items": Array [
                 <HeaderLogo
-<<<<<<< HEAD
-=======
-                  basePath={
-                    BasePath {
-                      "basePath": "/test",
-                      "get": [Function],
-                      "getBasePath": [Function],
-                      "prepend": [Function],
-                      "remove": [Function],
-                      "serverBasePath": "/test",
-                      "workspaceBasePath": "",
-                    }
-                  }
->>>>>>> 356e96dfed (Integrate workspace service into saved object management (#31))
                   branding={
                     Object {
                       "applicationTitle": "OpenSearch Dashboards",
@@ -2466,20 +2452,6 @@ exports[`Header handles visibility and lock changes 1`] = `
                   className="euiHeaderSectionItem"
                 >
                   <HeaderLogo
-<<<<<<< HEAD
-=======
-                    basePath={
-                      BasePath {
-                        "basePath": "/test",
-                        "get": [Function],
-                        "getBasePath": [Function],
-                        "prepend": [Function],
-                        "remove": [Function],
-                        "serverBasePath": "/test",
-                        "workspaceBasePath": "",
-                      }
-                    }
->>>>>>> 356e96dfed (Integrate workspace service into saved object management (#31))
                     branding={
                       Object {
                         "applicationTitle": "OpenSearch Dashboards",
@@ -3785,16 +3757,24 @@ exports[`Header handles visibility and lock changes 1`] = `
                   className="euiBreadcrumbs euiHeaderBreadcrumbs osdHeaderBreadcrumbs euiBreadcrumbs--truncate"
                   data-test-subj="breadcrumbs"
                 >
-                  <EuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
-                      data-test-subj="breadcrumb first last"
-                      title="test"
+                  <div
+                    className="euiBreadcrumbWall euiBreadcrumbWall--single"
+                  >
+                    <div
+                      className="euiBreadcrumbWrapper euiBreadcrumbWrapper--first euiBreadcrumbWrapper--last"
                     >
-                      test
-                    </span>
-                  </EuiInnerText>
+                      <EuiInnerText>
+                        <span
+                          aria-current="page"
+                          className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
+                          data-test-subj="breadcrumb first last"
+                          title="test"
+                        >
+                          test
+                        </span>
+                      </EuiInnerText>
+                    </div>
+                  </div>
                 </nav>
               </EuiBreadcrumbs>
             </EuiHeaderBreadcrumbs>
@@ -9479,16 +9459,24 @@ exports[`Header renders condensed header 1`] = `
                   className="euiBreadcrumbs euiHeaderBreadcrumbs osdHeaderBreadcrumbs euiBreadcrumbs--truncate"
                   data-test-subj="breadcrumbs"
                 >
-                  <EuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
-                      data-test-subj="breadcrumb first"
-                      title="test"
+                  <div
+                    className="euiBreadcrumbWall euiBreadcrumbWall--single"
+                  >
+                    <div
+                      className="euiBreadcrumbWrapper euiBreadcrumbWrapper--first euiBreadcrumbWrapper--last"
                     >
-                      test
-                    </span>
-                  </EuiInnerText>
+                      <EuiInnerText>
+                        <span
+                          aria-current="page"
+                          className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
+                          data-test-subj="breadcrumb first"
+                          title="test"
+                        >
+                          test
+                        </span>
+                      </EuiInnerText>
+                    </div>
+                  </div>
                 </nav>
               </EuiBreadcrumbs>
             </EuiHeaderBreadcrumbs>

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -373,7 +373,6 @@ export class SavedObjectsClient {
       namespaces: 'namespaces',
       preference: 'preference',
       workspaces: 'workspaces',
-      queryDSL: 'queryDSL',
     };
 
     const currentWorkspaceId = this._getCurrentWorkspace();
@@ -384,14 +383,17 @@ export class SavedObjectsClient {
       finalWorkspaces = Array.from(new Set([currentWorkspaceId]));
     }
 
-    const renamedQuery = renameKeys<SavedObjectsFindOptions, any>(renameMap, {
-      ...options,
-      ...(finalWorkspaces
-        ? {
-            workspaces: finalWorkspaces,
-          }
-        : {}),
-    });
+    const renamedQuery = renameKeys<Omit<SavedObjectsFindOptions, 'ACLSearchParams'>, any>(
+      renameMap,
+      {
+        ...options,
+        ...(finalWorkspaces
+          ? {
+              workspaces: finalWorkspaces,
+            }
+          : {}),
+      }
+    );
     const query = pick.apply(null, [renamedQuery, ...Object.values<string>(renameMap)]) as Partial<
       Record<string, any>
     >;

--- a/src/core/server/saved_objects/permission_control/client.ts
+++ b/src/core/server/saved_objects/permission_control/client.ts
@@ -6,8 +6,9 @@ import { i18n } from '@osd/i18n';
 import { OpenSearchDashboardsRequest } from '../../http';
 import { ensureRawRequest } from '../../http/router';
 import { SavedObjectsServiceStart } from '../saved_objects_service';
-import { SavedObjectsBulkGetObject, SavedObjectsRepository, SavedObjectsUtils } from '../service';
+import { SavedObjectsBulkGetObject } from '../service';
 import { ACL, Principals, TransformedPermission, PrincipalType } from './acl';
+import { WORKSPACE_TYPE } from '../../../utils';
 
 export type SavedObjectsPermissionControlContract = Pick<
   SavedObjectsPermissionControl,
@@ -127,11 +128,19 @@ export class SavedObjectsPermissionControl {
     permissionModes: SavedObjectsPermissionModes
   ) {
     const principals = this.getPrincipalsFromRequest(request);
-    const repository = this.getInternalRepository() as SavedObjectsRepository;
-    return await SavedObjectsUtils.getPermittedWorkspaceIds({
-      principals,
-      repository,
-      permissionModes,
-    });
+    const repository = this.getInternalRepository();
+    try {
+      const result = await repository?.find({
+        type: [WORKSPACE_TYPE],
+        ACLSearchParams: {
+          permissionModes,
+          principals,
+        },
+        perPage: 999,
+      });
+      return result?.saved_objects.map((item) => item.id);
+    } catch (e) {
+      return [];
+    }
   }
 }

--- a/src/core/server/saved_objects/service/lib/repository.mock.ts
+++ b/src/core/server/saved_objects/service/lib/repository.mock.ts
@@ -45,8 +45,6 @@ const create = (): jest.Mocked<ISavedObjectsRepository> => ({
   deleteByNamespace: jest.fn(),
   incrementCounter: jest.fn(),
   addToWorkspaces: jest.fn(),
-  getPermissionQuery: jest.fn(),
-  processFindOptions: jest.fn(),
   deleteByWorkspace: jest.fn(),
   deleteFromWorkspaces: jest.fn(),
 });

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -31,7 +31,6 @@
 import { omit, intersection } from 'lodash';
 import type { opensearchtypes } from '@opensearch-project/opensearch';
 import uuid from 'uuid';
-import { i18n } from '@osd/i18n';
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import { SavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import { DeleteDocumentResponse, OpenSearchClient } from '../../../opensearch/';
@@ -91,9 +90,7 @@ import {
   FIND_DEFAULT_PER_PAGE,
   SavedObjectsUtils,
 } from './utils';
-import { PUBLIC_WORKSPACE_ID, WorkspacePermissionMode } from '../../../../utils/constants';
-import { ACL, Principals } from '../../permission_control/acl';
-import { WORKSPACE_TYPE } from '../../../../utils';
+import { PUBLIC_WORKSPACE_ID } from '../../../../utils/constants';
 
 // BEWARE: The SavedObjectClient depends on the implementation details of the SavedObjectsRepository
 // so any breaking changes to this repository are considered breaking changes to the SavedObjectsClient.
@@ -902,7 +899,7 @@ export class SavedObjectsRepository {
       filter,
       preference,
       workspaces,
-      queryDSL,
+      ACLSearchParams,
     } = options;
 
     if (!type && !typeToNamespacesMap) {
@@ -977,7 +974,7 @@ export class SavedObjectsRepository {
           hasReference,
           kueryNode,
           workspaces,
-          queryDSL,
+          ACLSearchParams,
         }),
       },
     };
@@ -1934,111 +1931,6 @@ export class SavedObjectsRepository {
     };
   }
 
-  async getPermissionQuery(props: {
-    permissionTypes: string[];
-    principals: Principals;
-    savedObjectType?: string[];
-  }) {
-    return ACL.generateGetPermittedSavedObjectsQueryDSL(
-      props.permissionTypes,
-      props.principals,
-      props.savedObjectType
-    );
-  }
-
-  async processFindOptions(props: {
-    options: SavedObjectsFindOptions & { permissionModes?: string[] };
-    principals: Principals;
-  }): Promise<SavedObjectsFindOptions> {
-    const { principals } = props;
-    const options = { ...props.options };
-    if (this.isRelatedToWorkspace(options.type)) {
-      options.queryDSL = await this.getPermissionQuery({
-        permissionTypes: options.permissionModes ?? [
-          WorkspacePermissionMode.LibraryRead,
-          WorkspacePermissionMode.LibraryWrite,
-          WorkspacePermissionMode.Management,
-        ],
-        principals,
-        savedObjectType: [WORKSPACE_TYPE],
-      });
-    } else {
-      const permittedWorkspaceIds = await SavedObjectsUtils.getPermittedWorkspaceIds({
-        permissionModes: [
-          WorkspacePermissionMode.LibraryRead,
-          WorkspacePermissionMode.LibraryWrite,
-          WorkspacePermissionMode.Management,
-        ],
-        principals,
-        repository: this,
-      });
-
-      if (options.workspaces) {
-        const permittedWorkspaces = options.workspaces.filter((item) =>
-          (permittedWorkspaceIds || []).includes(item)
-        );
-        if (!permittedWorkspaces.length) {
-          /**
-           * If user does not have any one workspace access
-           * deny the request
-           */
-          throw SavedObjectsErrorHelpers.decorateNotAuthorizedError(
-            new Error(
-              i18n.translate('workspace.permission.invalidate', {
-                defaultMessage: 'Invalid workspace permission',
-              })
-            )
-          );
-        }
-
-        /**
-         * Overwrite the options.workspaces when user has access on partial workspaces.
-         */
-        options.workspaces = permittedWorkspaces;
-      } else {
-        const queryDSL = await this.getPermissionQuery({
-          permissionTypes: [WorkspacePermissionMode.Read, WorkspacePermissionMode.Write],
-          principals,
-          savedObjectType: Array.isArray(options.type) ? options.type : [options.type],
-        });
-        options.workspaces = undefined;
-        /**
-         * Select all the docs that
-         * 1. ACL matches read or write permission OR
-         * 2. workspaces matches library_read or library_write or management OR
-         * 3. Advanced settings
-         */
-        options.queryDSL = {
-          query: {
-            bool: {
-              filter: [
-                {
-                  bool: {
-                    should: [
-                      {
-                        term: {
-                          type: 'config',
-                        },
-                      },
-                      queryDSL.query,
-                      {
-                        terms: {
-                          workspaces: permittedWorkspaceIds,
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        };
-      }
-    }
-
-    return options;
-  }
-
   /**
    * Returns index specified by the given type or the default index
    *
@@ -2166,16 +2058,6 @@ export class SavedObjectsRepository {
       throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
     }
     return body;
-  }
-
-  /**
-   * check if the type include workspace
-   * Workspace permission check is totally different from object permission check.
-   * @param type
-   * @returns
-   */
-  private isRelatedToWorkspace(type: string | string[]): boolean {
-    return type === WORKSPACE_TYPE || (Array.isArray(type) && type.includes(WORKSPACE_TYPE));
   }
 }
 

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -34,6 +34,7 @@ import { IndexMapping } from '../../../mappings';
 import { getQueryParams } from './query_params';
 import { getSortingParams } from './sorting_params';
 import { ISavedObjectTypeRegistry } from '../../../saved_objects_type_registry';
+import { SavedObjectsFindOptions } from '../../../types';
 
 type KueryNode = any;
 
@@ -53,7 +54,7 @@ interface GetSearchDslOptions {
   };
   kueryNode?: KueryNode;
   workspaces?: string[];
-  queryDSL?: Record<string, any>;
+  ACLSearchParams?: SavedObjectsFindOptions['ACLSearchParams'];
 }
 
 export function getSearchDsl(
@@ -74,7 +75,7 @@ export function getSearchDsl(
     hasReference,
     kueryNode,
     workspaces,
-    queryDSL,
+    ACLSearchParams,
   } = options;
 
   if (!type) {
@@ -98,7 +99,7 @@ export function getSearchDsl(
       hasReference,
       kueryNode,
       workspaces,
-      queryDSL,
+      ACLSearchParams,
     }),
     ...getSortingParams(mappings, type, sortField, sortOrder),
   };

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -29,10 +29,7 @@
  */
 
 import { SavedObjectsFindOptions } from '../../types';
-import { SavedObjectsFindResponse, SavedObjectsRepository } from '..';
-import { Principals } from '../../permission_control/acl';
-import { SavedObjectsPermissionModes } from '../../permission_control/client';
-import { WORKSPACE_TYPE } from '../../../../utils';
+import { SavedObjectsFindResponse } from '..';
 
 export const DEFAULT_NAMESPACE_STRING = 'default';
 export const ALL_NAMESPACES_STRING = '*';
@@ -89,28 +86,5 @@ export class SavedObjectsUtils {
     baseWorkspaces?: string[]
   ): string[] {
     return targetWorkspaces?.filter((item) => !baseWorkspaces?.includes(item)) || [];
-  }
-
-  public static async getPermittedWorkspaceIds(props: {
-    principals: Principals;
-    repository: SavedObjectsRepository;
-    permissionModes: SavedObjectsPermissionModes;
-  }) {
-    const { principals, repository, permissionModes } = props;
-    const queryDSL = await repository.getPermissionQuery({
-      permissionTypes: permissionModes,
-      principals,
-      savedObjectType: [WORKSPACE_TYPE],
-    });
-    try {
-      const result = await repository?.find({
-        type: [WORKSPACE_TYPE],
-        queryDSL,
-        perPage: 999,
-      });
-      return result?.saved_objects.map((item) => item.id);
-    } catch (e) {
-      return [];
-    }
   }
 }

--- a/src/core/server/saved_objects/service/saved_objects_client.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.ts
@@ -28,8 +28,8 @@
  * under the License.
  */
 
-import { Permissions, Principals } from '../permission_control/acl';
-import { ISavedObjectsRepository, SavedObjectsRepository } from './lib';
+import { Permissions } from '../permission_control/acl';
+import { ISavedObjectsRepository } from './lib';
 import {
   SavedObject,
   SavedObjectError,
@@ -478,26 +478,6 @@ export class SavedObjectsClient {
     options: SavedObjectsAddToWorkspacesOptions = {}
   ): Promise<SavedObjectsAddToWorkspacesResponse[]> => {
     return await this._repository.addToWorkspaces(objects, workspaces, options);
-  };
-
-  /**
-   * Different DB may have different query DSL for given params
-   */
-  getPermissionQuery = async (
-    props: Parameters<SavedObjectsRepository['getPermissionQuery']>[0]
-  ) => {
-    return await this._repository.getPermissionQuery(props);
-  };
-
-  /**
-   * Different DB may have different query to find granted objects,
-   * provide a placeholder here for other query implementation
-   */
-  processFindOptions = async (props: {
-    options: SavedObjectsFindOptions;
-    principals: Principals;
-  }): Promise<SavedObjectsFindOptions> => {
-    return await this._repository.processFindOptions(props);
   };
 
   /**

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -45,6 +45,7 @@ export {
 } from './import/types';
 
 import { SavedObject } from '../../types';
+import { Principals } from './permission_control/acl';
 
 type KueryNode = any;
 
@@ -111,7 +112,14 @@ export interface SavedObjectsFindOptions {
   /** An optional OpenSearch preference value to be used for the query **/
   preference?: string;
   workspaces?: string[];
-  queryDSL?: Record<string, any>;
+  /**
+   * The params here will be combined with bool clause and is used for filtering with ACL structure.
+   */
+  ACLSearchParams?: {
+    workspaces?: string[];
+    principals?: Principals;
+    permissionModes?: string[];
+  };
 }
 
 /**


### PR DESCRIPTION
…ds declaration in repositoryClient (#142)

* refractor: remove additional method declaration

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: make bootstrap run

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: change to single permission modes

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: rename variable

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

---------

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>
(cherry picked from commit 05fab00a1e9f90ccfae754bd4073c3fa4954b774)

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
