### PR TITLE
disable github workflows running on windows for development

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -298,6 +298,7 @@ jobs:
           retention-days: 1
 
   bwc-tests:
+    if: false
     needs: [build-min-artifact-tests]
     runs-on: arc-runner-set
     container:

--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -33,13 +33,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-runner-set, windows-latest]
+        os: [arc-runner-set]
         group: [1, 2, 3, 4]
         include:
           - os: arc-runner-set
             name: Linux
-          - os: windows-latest
-            name: Windows
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git's autocrlf (Windows only)
@@ -130,13 +128,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-runner-set, windows-latest]
+        os: [arc-runner-set]
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         include:
           - os: arc-runner-set
             name: Linux
-          - os: windows-latest
-            name: Windows
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo Running functional tests for ciGroup${{ matrix.group }}
@@ -227,11 +223,6 @@ jobs:
             ext: tar.gz
             suffix: linux-arm64
             script: build-platform --linux-arm --skip-os-packages
-          - os: windows-latest
-            name: Windows x64
-            ext: zip
-            suffix: windows-x64
-            script: build-platform --windows --skip-os-packages
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   cypress-tests:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001


### PR DESCRIPTION
the jobs for windows are queued forever, disable it for development

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
