### PR TITLE
[Backport workspace-2.9]Refractor: move permission control service to workspace directory and keep saved objects as clean as possible (#166)

### DIFF
--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -326,7 +326,9 @@ export {
   SavedObjectsDeleteByWorkspaceOptions,
   Permissions,
   ACL,
-  SavedObjectsPermissionControlContract,
+  Principals,
+  TransformedPermission,
+  PrincipalType,
 } from './saved_objects';
 
 export {

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -276,7 +276,6 @@ export class LegacyService implements CoreService {
         registerType: setupDeps.core.savedObjects.registerType,
         getImportExportObjectLimit: setupDeps.core.savedObjects.getImportExportObjectLimit,
         setRepositoryFactoryProvider: setupDeps.core.savedObjects.setRepositoryFactoryProvider,
-        permissionControl: setupDeps.core.savedObjects.permissionControl,
       },
       status: {
         isStatusPageAnonymous: setupDeps.core.status.isStatusPageAnonymous,

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -205,7 +205,6 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>(
       registerType: deps.savedObjects.registerType,
       getImportExportObjectLimit: deps.savedObjects.getImportExportObjectLimit,
       setRepositoryFactoryProvider: deps.savedObjects.setRepositoryFactoryProvider,
-      permissionControl: deps.savedObjects.permissionControl,
     },
     status: {
       core$: deps.status.core$,

--- a/src/core/server/saved_objects/index.ts
+++ b/src/core/server/saved_objects/index.ts
@@ -85,5 +85,10 @@ export {
 export { savedObjectsConfig, savedObjectsMigrationConfig } from './saved_objects_config';
 export { SavedObjectTypeRegistry, ISavedObjectTypeRegistry } from './saved_objects_type_registry';
 
-export { Permissions, ACL } from './permission_control/acl';
-export { SavedObjectsPermissionControlContract } from './permission_control/client';
+export {
+  Permissions,
+  ACL,
+  Principals,
+  TransformedPermission,
+  PrincipalType,
+} from './permission_control/acl';

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -45,7 +45,6 @@ import { typeRegistryMock } from './saved_objects_type_registry.mock';
 import { migrationMocks } from './migrations/mocks';
 import { ServiceStatusLevels } from '../status';
 import { ISavedObjectTypeRegistry } from './saved_objects_type_registry';
-import { savedObjectsPermissionControlMock } from './permission_control/client.mock';
 
 type SavedObjectsServiceContract = PublicMethodsOf<SavedObjectsService>;
 
@@ -81,7 +80,6 @@ const createSetupContractMock = () => {
     registerType: jest.fn(),
     getImportExportObjectLimit: jest.fn(),
     setRepositoryFactoryProvider: jest.fn(),
-    permissionControl: savedObjectsPermissionControlMock,
   };
 
   setupContract.getImportExportObjectLimit.mockReturnValue(100);

--- a/src/plugins/workspace/server/permission_control/client.mock.ts
+++ b/src/plugins/workspace/server/permission_control/client.mock.ts
@@ -5,7 +5,6 @@
 import { SavedObjectsPermissionControlContract } from './client';
 
 export const savedObjectsPermissionControlMock: SavedObjectsPermissionControlContract = {
-  setup: jest.fn(),
   validate: jest.fn(),
   batchValidate: jest.fn(),
   getPrincipalsOfObjects: jest.fn(),

--- a/src/plugins/workspace/server/permission_control/client.ts
+++ b/src/plugins/workspace/server/permission_control/client.ts
@@ -3,13 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { i18n } from '@osd/i18n';
-import { OpenSearchDashboardsRequest } from '../../http';
-import { ensureRawRequest } from '../../http/router';
-import { SavedObjectsServiceStart } from '../saved_objects_service';
-import { SavedObjectsBulkGetObject } from '../service';
-import { ACL, Principals, TransformedPermission, PrincipalType } from './acl';
-import { WORKSPACE_TYPE } from '../../../utils';
-import { Logger } from '../../logging';
+import { ensureRawRequest, OpenSearchDashboardsRequest } from '../../../../core/server';
+import {
+  ACL,
+  Principals,
+  TransformedPermission,
+  PrincipalType,
+  SavedObjectsBulkGetObject,
+  SavedObjectsServiceStart,
+  Logger,
+  WORKSPACE_TYPE,
+} from '../../../../core/server';
+import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../../common/constants';
 
 export type SavedObjectsPermissionControlContract = Pick<
   SavedObjectsPermissionControl,
@@ -25,9 +30,11 @@ export interface AuthInfo {
 
 export class SavedObjectsPermissionControl {
   private readonly logger: Logger;
-  private createInternalRepository?: SavedObjectsServiceStart['createInternalRepository'];
-  private getInternalRepository() {
-    return this.createInternalRepository?.();
+  private _getScopedClient?: SavedObjectsServiceStart['getScopedClient'];
+  private getScopedClient(request: OpenSearchDashboardsRequest) {
+    return this._getScopedClient?.(request, {
+      excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+    });
   }
 
   constructor(logger: Logger) {
@@ -65,12 +72,10 @@ export class SavedObjectsPermissionControl {
     request: OpenSearchDashboardsRequest,
     savedObjects: SavedObjectsBulkGetObject[]
   ) {
-    return (await this.getInternalRepository()?.bulkGet(savedObjects))?.saved_objects || [];
+    return (await this.getScopedClient?.(request)?.bulkGet(savedObjects))?.saved_objects || [];
   }
-  public async setup(
-    createInternalRepository: SavedObjectsServiceStart['createInternalRepository']
-  ) {
-    this.createInternalRepository = createInternalRepository;
+  public async setup(getScopedClient: SavedObjectsServiceStart['getScopedClient']) {
+    this._getScopedClient = getScopedClient;
   }
   public async validate(
     request: OpenSearchDashboardsRequest,
@@ -164,9 +169,9 @@ export class SavedObjectsPermissionControl {
     permissionModes: SavedObjectsPermissionModes
   ) {
     const principals = this.getPrincipalsFromRequest(request);
-    const repository = this.getInternalRepository();
+    const savedObjectClient = this.getScopedClient?.(request);
     try {
-      const result = await repository?.find({
+      const result = await savedObjectClient?.find({
         type: [WORKSPACE_TYPE],
         ACLSearchParams: {
           permissionModes,

--- a/src/plugins/workspace/server/permission_control/routes/index.ts
+++ b/src/plugins/workspace/server/permission_control/routes/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalHttpServiceSetup } from '../../../http';
+import { HttpServiceSetup } from '../../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../client';
 import { registerListRoute } from './principals';
 import { registerValidateRoute } from './validate';
@@ -12,10 +12,10 @@ export function registerPermissionCheckRoutes({
   http,
   permissionControl,
 }: {
-  http: InternalHttpServiceSetup;
+  http: HttpServiceSetup;
   permissionControl: SavedObjectsPermissionControlContract;
 }) {
-  const router = http.createRouter('/api/saved_objects_permission_control/');
+  const router = http.createRouter();
 
   registerValidateRoute(router, permissionControl);
   registerListRoute(router, permissionControl);

--- a/src/plugins/workspace/server/permission_control/routes/principals.ts
+++ b/src/plugins/workspace/server/permission_control/routes/principals.ts
@@ -4,8 +4,9 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { IRouter } from '../../../http';
+import { IRouter } from '../../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../client';
+import { WORKSPACES_API_BASE_URL } from '../../routes';
 
 export const registerListRoute = (
   router: IRouter,
@@ -13,7 +14,7 @@ export const registerListRoute = (
 ) => {
   router.post(
     {
-      path: '/principals',
+      path: `${WORKSPACES_API_BASE_URL}/principals`,
       validate: {
         body: schema.object({
           objects: schema.arrayOf(

--- a/src/plugins/workspace/server/permission_control/routes/validate.ts
+++ b/src/plugins/workspace/server/permission_control/routes/validate.ts
@@ -4,8 +4,9 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { IRouter } from '../../../http';
+import { IRouter } from '../../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../client';
+import { WORKSPACES_API_BASE_URL } from '../../routes';
 
 export const registerValidateRoute = (
   router: IRouter,
@@ -13,7 +14,7 @@ export const registerValidateRoute = (
 ) => {
   router.post(
     {
-      path: '/validate/{type}/{id}',
+      path: `${WORKSPACES_API_BASE_URL}/validate/{type}/{id}`,
       validate: {
         params: schema.object({
           type: schema.string(),

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../core/server';
 import { IWorkspaceDBImpl, WorkspaceRoutePermissionItem } from '../types';
 
-const WORKSPACES_API_BASE_URL = '/api/workspaces';
+export const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
 const workspacePermissionMode = schema.oneOf([
   schema.literal(WorkspacePermissionMode.LibraryRead),


### PR DESCRIPTION
* refractor: move permission control service to workspace directory and keep saved objects as clean as possible

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: make lint pass

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

---------

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>
(cherry picked from commit c2a9bd24acba983353f43db80ec98f54ba7e15c3)

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
