### PR TITLE
feat: use passed ACLSearchParams.permissionModes

### DIFF
--- a/src/plugins/workspace/server/permission_control/client.ts
+++ b/src/plugins/workspace/server/permission_control/client.ts
@@ -10,7 +10,6 @@ import {
   SavedObjectsBulkGetObject,
   SavedObjectsServiceStart,
   Logger,
-  WORKSPACE_TYPE,
 } from '../../../../core/server';
 import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../../common/constants';
 import { getPrincipalsFromRequest } from '../utils';
@@ -129,26 +128,5 @@ export class SavedObjectsPermissionControl {
         [current.id]: new ACL(current.permissions).toFlatList(),
       };
     }, {});
-  }
-
-  public async getPermittedWorkspaceIds(
-    request: OpenSearchDashboardsRequest,
-    permissionModes: SavedObjectsPermissionModes
-  ) {
-    const principals = getPrincipalsFromRequest(request);
-    const savedObjectClient = this.getScopedClient?.(request);
-    try {
-      const result = await savedObjectClient?.find({
-        type: [WORKSPACE_TYPE],
-        ACLSearchParams: {
-          permissionModes,
-          principals,
-        },
-        perPage: 999,
-      });
-      return result?.saved_objects.map((item) => item.id);
-    } catch (e) {
-      return [];
-    }
   }
 }

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -30,7 +30,6 @@ import {
   SavedObjectsErrorHelpers,
 } from '../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
-import { WorkspaceFindOptions } from '../types';
 import { getPrincipalsFromRequest } from '../utils';
 
 const ALL_WORKSPACE_INNER_DATA_PERMISSION_MODES: string[] = [
@@ -361,7 +360,7 @@ export class WorkspaceSavedObjectsClientWrapper {
     };
 
     const findWithWorkspacePermissionControl = async <T = unknown>(
-      options: SavedObjectsFindOptions & Pick<WorkspaceFindOptions, 'permissionModes'>
+      options: SavedObjectsFindOptions
     ) => {
       const principals = getPrincipalsFromRequest(wrapperOptions.request);
       if (!options.ACLSearchParams) {

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -378,10 +378,16 @@ export class WorkspaceSavedObjectsClientWrapper {
         options.ACLSearchParams.permissionModes = workspaceInnerPermissionModes;
         options.ACLSearchParams.principals = principals;
       } else {
-        const permittedWorkspaceIds = await this.permissionControl.getPermittedWorkspaceIds(
-          wrapperOptions.request,
-          workspaceInnerPermissionModes
-        );
+        const permittedWorkspaceIds = (
+          await wrapperOptions.client.find({
+            type: WORKSPACE_TYPE,
+            perPage: 999,
+            ACLSearchParams: {
+              principals,
+              permissionModes: workspaceInnerPermissionModes,
+            },
+          })
+        ).saved_objects.map((item) => item.id);
 
         if (options.workspaces) {
           const permittedWorkspaces = options.workspaces.filter((item) =>

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -4,6 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
+import { intersection } from 'lodash';
 
 import {
   OpenSearchDashboardsRequest,
@@ -31,6 +32,12 @@ import {
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
 import { WorkspaceFindOptions } from '../types';
 import { getPrincipalsFromRequest } from '../utils';
+
+const ALL_WORKSPACE_INNER_DATA_PERMISSION_MODES: string[] = [
+  WorkspacePermissionMode.LibraryRead,
+  WorkspacePermissionMode.LibraryWrite,
+  WorkspacePermissionMode.Management,
+];
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized
 const generateWorkspacePermissionError = () => {
@@ -360,21 +367,20 @@ export class WorkspaceSavedObjectsClientWrapper {
       if (!options.ACLSearchParams) {
         options.ACLSearchParams = {};
       }
+      const workspaceInnerPermissionModes = options.ACLSearchParams.permissionModes
+        ? intersection(
+            options.ACLSearchParams.permissionModes,
+            ALL_WORKSPACE_INNER_DATA_PERMISSION_MODES
+          )
+        : ALL_WORKSPACE_INNER_DATA_PERMISSION_MODES;
+
       if (this.isRelatedToWorkspace(options.type)) {
-        options.ACLSearchParams.permissionModes = options.permissionModes ?? [
-          WorkspacePermissionMode.LibraryRead,
-          WorkspacePermissionMode.LibraryWrite,
-          WorkspacePermissionMode.Management,
-        ];
+        options.ACLSearchParams.permissionModes = workspaceInnerPermissionModes;
         options.ACLSearchParams.principals = principals;
       } else {
         const permittedWorkspaceIds = await this.permissionControl.getPermittedWorkspaceIds(
           wrapperOptions.request,
-          [
-            WorkspacePermissionMode.LibraryRead,
-            WorkspacePermissionMode.LibraryWrite,
-            WorkspacePermissionMode.Management,
-          ]
+          workspaceInnerPermissionModes
         );
 
         if (options.workspaces) {
@@ -408,10 +414,12 @@ export class WorkspaceSavedObjectsClientWrapper {
            */
           options.workspaces = undefined;
           options.ACLSearchParams.workspaces = permittedWorkspaceIds;
-          options.ACLSearchParams.permissionModes = [
-            WorkspacePermissionMode.Read,
-            WorkspacePermissionMode.Write,
-          ];
+          options.ACLSearchParams.permissionModes = options.ACLSearchParams.permissionModes
+            ? intersection(options.ACLSearchParams.permissionModes, [
+                WorkspacePermissionMode.Read,
+                WorkspacePermissionMode.Write,
+              ])
+            : [WorkspacePermissionMode.Read, WorkspacePermissionMode.Write];
           options.ACLSearchParams.principals = principals;
         }
       }

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -228,11 +228,13 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
     options: WorkspaceFindOptions
   ): ReturnType<IWorkspaceDBImpl['list']> {
     try {
+      const { permissionModes, ...restOptions } = options;
       const resultResp = await this.getSavedObjectClientsFromRequestDetail(requestDetail).find<
         WorkspaceAttribute
       >({
-        ...options,
+        ...restOptions,
         type: WORKSPACE_TYPE,
+        ...(permissionModes ? { ACLSearchParams: { permissionModes } } : {}),
       });
       const others = omit(resultResp, 'saved_objects');
       let savedObjects = resultResp.saved_objects;
@@ -284,8 +286,9 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
           const retryFindResp = await this.getSavedObjectClientsFromRequestDetail(
             requestDetail
           ).find<WorkspaceAttribute>({
-            ...options,
+            ...restOptions,
             type: WORKSPACE_TYPE,
+            ...(permissionModes ? { ACLSearchParams: { permissionModes } } : {}),
           });
           savedObjects = retryFindResp.saved_objects;
         }


### PR DESCRIPTION
### Description

1. use passed ACLSearchParams.permissionModes
2. move getPermittedWorkspaceIds to find method
3. remove permissionModes parameter, use `ACLSearchParams.permissionModes` instead

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
