### PR TITLE
 [Workspace] Add optional workspaces parameter to all saved objects API

### DIFF
--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -345,6 +345,7 @@ export class SavedObjectsClient {
       filter: 'filter',
       namespaces: 'namespaces',
       preference: 'preference',
+      workspaces: 'workspaces',
     };
 
     const renamedQuery = renameKeys<SavedObjectsFindOptions, any>(renameMap, options);

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -128,6 +128,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -218,6 +219,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -368,6 +370,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -459,6 +462,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -666,6 +670,7 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
+              workspaces: undefined,
             },
           ],
         ],
@@ -784,6 +789,7 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
+              workspaces: undefined,
             },
           ],
           Array [

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -128,7 +128,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -219,7 +218,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -370,7 +368,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -462,7 +459,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -670,7 +666,6 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
-              workspaces: undefined,
             },
           ],
         ],
@@ -789,7 +784,6 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
-              workspaces: undefined,
             },
           ],
           Array [

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -111,7 +111,6 @@ async function fetchObjectsToExport({
     }
     const bulkGetResult = await savedObjectsClient.bulkGet(objects, {
       namespace,
-      ...(workspaces ? { workspaces } : {}),
     });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -109,7 +109,10 @@ async function fetchObjectsToExport({
     if (typeof search === 'string') {
       throw Boom.badRequest(`Can't specify both "search" and "objects" properties when exporting`);
     }
-    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace, workspaces });
+    const bulkGetResult = await savedObjectsClient.bulkGet(objects, {
+      namespace,
+      ...(workspaces ? { workspaces } : {}),
+    });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {
       const err = Boom.badRequest();
@@ -125,7 +128,7 @@ async function fetchObjectsToExport({
       search,
       perPage: exportSizeLimit,
       namespaces: namespace ? [namespace] : undefined,
-      workspaces,
+      ...(workspaces ? { workspaces } : {}),
     });
     if (findResponse.total > exportSizeLimit) {
       throw Boom.badRequest(`Can't export more than ${exportSizeLimit} objects`);

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -60,6 +60,8 @@ export interface SavedObjectsExportOptions {
   excludeExportDetails?: boolean;
   /** optional namespace to override the namespace used by the savedObjectsClient. */
   namespace?: string;
+  /** optional workspaces to override the workspaces used by the savedObjectsClient. */
+  workspaces?: string[];
 }
 
 /**
@@ -87,6 +89,7 @@ async function fetchObjectsToExport({
   exportSizeLimit,
   savedObjectsClient,
   namespace,
+  workspaces,
 }: {
   objects?: SavedObjectsExportOptions['objects'];
   types?: string[];
@@ -94,6 +97,7 @@ async function fetchObjectsToExport({
   exportSizeLimit: number;
   savedObjectsClient: SavedObjectsClientContract;
   namespace?: string;
+  workspaces?: string[];
 }) {
   if ((types?.length ?? 0) > 0 && (objects?.length ?? 0) > 0) {
     throw Boom.badRequest(`Can't specify both "types" and "objects" properties when exporting`);
@@ -105,7 +109,7 @@ async function fetchObjectsToExport({
     if (typeof search === 'string') {
       throw Boom.badRequest(`Can't specify both "search" and "objects" properties when exporting`);
     }
-    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace });
+    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace, workspaces });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {
       const err = Boom.badRequest();
@@ -121,6 +125,7 @@ async function fetchObjectsToExport({
       search,
       perPage: exportSizeLimit,
       namespaces: namespace ? [namespace] : undefined,
+      workspaces,
     });
     if (findResponse.total > exportSizeLimit) {
       throw Boom.badRequest(`Can't export more than ${exportSizeLimit} objects`);
@@ -153,6 +158,7 @@ export async function exportSavedObjectsToStream({
   includeReferencesDeep = false,
   excludeExportDetails = false,
   namespace,
+  workspaces,
 }: SavedObjectsExportOptions) {
   const rootObjects = await fetchObjectsToExport({
     types,
@@ -161,6 +167,7 @@ export async function exportSavedObjectsToStream({
     savedObjectsClient,
     exportSizeLimit,
     namespace,
+    workspaces,
   });
   let exportedObjects: Array<SavedObject<unknown>> = [];
   let missingReferences: SavedObjectsExportResultDetails['missingReferences'] = [];

--- a/src/core/server/saved_objects/import/check_conflicts.ts
+++ b/src/core/server/saved_objects/import/check_conflicts.ts
@@ -44,6 +44,7 @@ interface CheckConflictsParams {
   ignoreRegularConflicts?: boolean;
   retries?: SavedObjectsImportRetry[];
   createNewCopies?: boolean;
+  workspaces?: string[];
 }
 
 const isUnresolvableConflict = (error: SavedObjectError) =>
@@ -56,6 +57,7 @@ export async function checkConflicts({
   ignoreRegularConflicts,
   retries = [],
   createNewCopies,
+  workspaces,
 }: CheckConflictsParams) {
   const filteredObjects: Array<SavedObject<{ title?: string }>> = [];
   const errors: SavedObjectsImportError[] = [];
@@ -77,6 +79,7 @@ export async function checkConflicts({
   });
   const checkConflictsResult = await savedObjectsClient.checkConflicts(objectsToCheck, {
     namespace,
+    workspaces,
   });
   const errorMap = checkConflictsResult.errors.reduce(
     (acc, { type, id, error }) => acc.set(`${type}:${id}`, error),

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -39,6 +39,7 @@ interface CreateSavedObjectsParams<T> {
   importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
   namespace?: string;
   overwrite?: boolean;
+  workspaces?: string[];
 }
 interface CreateSavedObjectsResult<T> {
   createdObjects: Array<CreatedObject<T>>;
@@ -56,6 +57,7 @@ export const createSavedObjects = async <T>({
   importIdMap,
   namespace,
   overwrite,
+  workspaces,
 }: CreateSavedObjectsParams<T>): Promise<CreateSavedObjectsResult<T>> => {
   // filter out any objects that resulted in errors
   const errorSet = accumulatedErrors.reduce(
@@ -103,6 +105,7 @@ export const createSavedObjects = async <T>({
     const bulkCreateResponse = await savedObjectsClient.bulkCreate(objectsToCreate, {
       namespace,
       overwrite,
+      workspaces,
     });
     expectedResults = bulkCreateResponse.saved_objects;
   }
@@ -110,7 +113,7 @@ export const createSavedObjects = async <T>({
   // remap results to reflect the object IDs that were submitted for import
   // this ensures that consumers understand the results
   const remappedResults = expectedResults.map<CreatedObject<T>>((result) => {
-    const { id } = objectIdMap.get(`${result.type}:${result.id}`)!;
+    const { id } = objectIdMap.get(`${result.type}:${result.id}`) || ({} as SavedObject<T>);
     // also, include a `destinationId` field if the object create attempt was made with a different ID
     return { ...result, id, ...(id !== result.id && { destinationId: result.id }) };
   });

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -113,7 +113,7 @@ export const createSavedObjects = async <T>({
   // remap results to reflect the object IDs that were submitted for import
   // this ensures that consumers understand the results
   const remappedResults = expectedResults.map<CreatedObject<T>>((result) => {
-    const { id } = objectIdMap.get(`${result.type}:${result.id}`) || ({} as SavedObject<T>);
+    const { id } = objectIdMap.get(`${result.type}:${result.id}`)!;
     // also, include a `destinationId` field if the object create attempt was made with a different ID
     return { ...result, id, ...(id !== result.id && { destinationId: result.id }) };
   });

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -42,7 +42,7 @@ import { typeRegistryMock } from '../saved_objects_type_registry.mock';
 import { importSavedObjectsFromStream } from './import_saved_objects';
 
 import { collectSavedObjects } from './collect_saved_objects';
-import { regenerateIds } from './regenerate_ids';
+import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
 import { validateReferences } from './validate_references';
 import { checkConflicts } from './check_conflicts';
 import { checkOriginConflicts } from './check_origin_conflicts';
@@ -68,6 +68,7 @@ describe('#importSavedObjectsFromStream', () => {
       importIdMap: new Map(),
     });
     getMockFn(regenerateIds).mockReturnValue(new Map());
+    getMockFn(regenerateIdsWithReference).mockReturnValue(Promise.resolve(new Map()));
     getMockFn(validateReferences).mockResolvedValue([]);
     getMockFn(checkConflicts).mockResolvedValue({
       errors: [],
@@ -240,6 +241,15 @@ describe('#importSavedObjectsFromStream', () => {
           ]),
         });
         getMockFn(validateReferences).mockResolvedValue([errors[1]]);
+        getMockFn(regenerateIdsWithReference).mockResolvedValue(
+          Promise.resolve(
+            new Map([
+              ['foo', {}],
+              ['bar', {}],
+              ['baz', {}],
+            ])
+          )
+        );
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [errors[2]],
           filteredObjects,

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -38,7 +38,7 @@ import { validateReferences } from './validate_references';
 import { checkOriginConflicts } from './check_origin_conflicts';
 import { createSavedObjects } from './create_saved_objects';
 import { checkConflicts } from './check_conflicts';
-import { regenerateIds } from './regenerate_ids';
+import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
 
 /**
  * Import saved objects from given stream. See the {@link SavedObjectsImportOptions | options} for more
@@ -81,12 +81,20 @@ export async function importSavedObjectsFromStream({
   if (createNewCopies) {
     importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects);
   } else {
+    importIdMap = await regenerateIdsWithReference({
+      savedObjects: collectSavedObjectsResult.collectedObjects,
+      savedObjectsClient,
+      workspaces,
+      objectLimit,
+      importIdMap,
+    });
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
     const checkConflictsParams = {
       objects: collectSavedObjectsResult.collectedObjects,
       savedObjectsClient,
       namespace,
       ignoreRegularConflicts: overwrite,
+      workspaces,
     };
     const checkConflictsResult = await checkConflicts(checkConflictsParams);
     errorAccumulator = [...errorAccumulator, ...checkConflictsResult.errors];
@@ -119,7 +127,7 @@ export async function importSavedObjectsFromStream({
     importIdMap,
     overwrite,
     namespace,
-    workspaces,
+    ...(workspaces ? { workspaces } : {}),
   };
   const createSavedObjectsResult = await createSavedObjects(createSavedObjectsParams);
   errorAccumulator = [...errorAccumulator, ...createSavedObjectsResult.errors];

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -54,6 +54,7 @@ export async function importSavedObjectsFromStream({
   savedObjectsClient,
   typeRegistry,
   namespace,
+  workspaces,
 }: SavedObjectsImportOptions): Promise<SavedObjectsImportResponse> {
   let errorAccumulator: SavedObjectsImportError[] = [];
   const supportedTypes = typeRegistry.getImportableAndExportableTypes().map((type) => type.name);
@@ -118,6 +119,7 @@ export async function importSavedObjectsFromStream({
     importIdMap,
     overwrite,
     namespace,
+    workspaces,
   };
   const createSavedObjectsResult = await createSavedObjects(createSavedObjectsParams);
   errorAccumulator = [...errorAccumulator, ...createSavedObjectsResult.errors];

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -81,13 +81,15 @@ export async function importSavedObjectsFromStream({
   if (createNewCopies) {
     importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects);
   } else {
-    importIdMap = await regenerateIdsWithReference({
-      savedObjects: collectSavedObjectsResult.collectedObjects,
-      savedObjectsClient,
-      workspaces,
-      objectLimit,
-      importIdMap,
-    });
+    if (workspaces) {
+      importIdMap = await regenerateIdsWithReference({
+        savedObjects: collectSavedObjectsResult.collectedObjects,
+        savedObjectsClient,
+        workspaces,
+        objectLimit,
+        importIdMap,
+      });
+    }
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
     const checkConflictsParams = {
       objects: collectSavedObjectsResult.collectedObjects,

--- a/src/core/server/saved_objects/import/regenerate_ids.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.ts
@@ -47,16 +47,11 @@ export const regenerateIds = (objects: SavedObject[]) => {
 export const regenerateIdsWithReference = async (props: {
   savedObjects: SavedObject[];
   savedObjectsClient: SavedObjectsClientContract;
-  workspaces?: string[];
+  workspaces: string[];
   objectLimit: number;
   importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
 }): Promise<Map<string, { id?: string; omitOriginId?: boolean }>> => {
   const { savedObjects, savedObjectsClient, workspaces, importIdMap } = props;
-  if (!workspaces || !workspaces.length) {
-    return savedObjects.reduce((acc, object) => {
-      return acc.set(`${object.type}:${object.id}`, { id: object.id, omitOriginId: false });
-    }, importIdMap);
-  }
 
   const bulkGetResult = await savedObjectsClient.bulkGet(
     savedObjects.map((item) => ({ type: item.type, id: item.id }))

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -59,6 +59,7 @@ export async function resolveSavedObjectsImportErrors({
   typeRegistry,
   namespace,
   createNewCopies,
+  workspaces,
 }: SavedObjectsResolveImportErrorsOptions): Promise<SavedObjectsImportResponse> {
   // throw a BadRequest error if we see invalid retries
   validateRetries(retries);
@@ -157,6 +158,7 @@ export async function resolveSavedObjectsImportErrors({
       importIdMap,
       namespace,
       overwrite,
+      workspaces,
     };
     const { createdObjects, errors: bulkCreateErrors } = await createSavedObjects(
       createSavedObjectsParams

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -187,6 +187,8 @@ export interface SavedObjectsImportOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  /** if specified, will import in given workspaces, else will import as global object */
+  workspaces?: string[];
 }
 
 /**
@@ -208,6 +210,8 @@ export interface SavedObjectsResolveImportErrorsOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  /** if specified, will import in given workspaces, else will import as global object */
+  workspaces?: string[];
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };

--- a/src/core/server/saved_objects/migrations/core/__snapshots__/build_active_mappings.test.ts.snap
+++ b/src/core/server/saved_objects/migrations/core/__snapshots__/build_active_mappings.test.ts.snap
@@ -14,6 +14,7 @@ Object {
       "references": "7997cf5a56cc02bdc9c93361bde732b0",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -111,6 +112,9 @@ Object {
     "updated_at": Object {
       "type": "date",
     },
+    "workspaces": Object {
+      "type": "keyword",
+    },
   },
 }
 `;
@@ -130,6 +134,7 @@ Object {
       "thirdType": "510f1f0adb69830cf8a1c5ce2923ed82",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -243,6 +248,9 @@ Object {
     },
     "updated_at": Object {
       "type": "date",
+    },
+    "workspaces": Object {
+      "type": "keyword",
     },
   },
 }

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
@@ -186,6 +186,9 @@ function defaultMapping(): IndexMapping {
           },
         },
       },
+      workspaces: {
+        type: 'keyword',
+      },
       permissions: {
         properties: {
           read: principals,

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -83,6 +83,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -93,6 +94,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             permissions: {
               properties: {
                 library_read: {
@@ -235,6 +239,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -246,6 +251,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             permissions: {
               properties: {
                 library_read: {
@@ -331,6 +339,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -342,6 +351,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             permissions: {
               properties: {
                 library_read: {

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/__snapshots__/opensearch_dashboards_migrator.test.ts.snap
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/__snapshots__/opensearch_dashboards_migrator.test.ts.snap
@@ -14,6 +14,7 @@ Object {
       "references": "7997cf5a56cc02bdc9c93361bde732b0",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -118,6 +119,9 @@ Object {
     },
     "updated_at": Object {
       "type": "date",
+    },
+    "workspaces": Object {
+      "type": "keyword",
     },
   },
 }

--- a/src/core/server/saved_objects/routes/bulk_create.ts
+++ b/src/core/server/saved_objects/routes/bulk_create.ts
@@ -38,6 +38,9 @@ export const registerBulkCreateRoute = (router: IRouter) => {
       validate: {
         query: schema.object({
           overwrite: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
         body: schema.arrayOf(
           schema.object({
@@ -62,7 +65,14 @@ export const registerBulkCreateRoute = (router: IRouter) => {
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const { overwrite } = req.query;
-      const result = await context.core.savedObjects.client.bulkCreate(req.body, { overwrite });
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+      const result = await context.core.savedObjects.client.bulkCreate(req.body, {
+        overwrite,
+        workspaces,
+      });
       return res.ok({ body: result });
     })
   );

--- a/src/core/server/saved_objects/routes/create.ts
+++ b/src/core/server/saved_objects/routes/create.ts
@@ -56,15 +56,23 @@ export const registerCreateRoute = (router: IRouter) => {
             )
           ),
           initialNamespaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+          workspaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
         }),
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const { type, id } = req.params;
       const { overwrite } = req.query;
-      const { attributes, migrationVersion, references, initialNamespaces } = req.body;
+      const { attributes, migrationVersion, references, initialNamespaces, workspaces } = req.body;
 
-      const options = { id, overwrite, migrationVersion, references, initialNamespaces };
+      const options = {
+        id,
+        overwrite,
+        migrationVersion,
+        references,
+        initialNamespaces,
+        workspaces,
+      };
       const result = await context.core.savedObjects.client.create(type, attributes, options);
       return res.ok({ body: result });
     })

--- a/src/core/server/saved_objects/routes/export.ts
+++ b/src/core/server/saved_objects/routes/export.ts
@@ -57,12 +57,20 @@ export const registerExportRoute = (router: IRouter, config: SavedObjectConfig) 
           search: schema.maybe(schema.string()),
           includeReferencesDeep: schema.boolean({ defaultValue: false }),
           excludeExportDetails: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(schema.arrayOf(schema.string())),
         }),
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const savedObjectsClient = context.core.savedObjects.client;
-      const { type, objects, search, excludeExportDetails, includeReferencesDeep } = req.body;
+      const {
+        type,
+        objects,
+        search,
+        excludeExportDetails,
+        includeReferencesDeep,
+        workspaces,
+      } = req.body;
       const types = typeof type === 'string' ? [type] : type;
 
       // need to access the registry for type validation, can't use the schema for this
@@ -98,6 +106,7 @@ export const registerExportRoute = (router: IRouter, config: SavedObjectConfig) 
         exportSizeLimit: maxImportExportSize,
         includeReferencesDeep,
         excludeExportDetails,
+        workspaces,
       });
 
       const docsToExport: string[] = await createPromiseFromStreams([

--- a/src/core/server/saved_objects/routes/find.ts
+++ b/src/core/server/saved_objects/routes/find.ts
@@ -59,6 +59,9 @@ export const registerFindRoute = (router: IRouter) => {
           namespaces: schema.maybe(
             schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
           ),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
       },
     },
@@ -67,6 +70,10 @@ export const registerFindRoute = (router: IRouter) => {
 
       const namespaces =
         typeof req.query.namespaces === 'string' ? [req.query.namespaces] : req.query.namespaces;
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
 
       const result = await context.core.savedObjects.client.find({
         perPage: query.per_page,
@@ -81,6 +88,7 @@ export const registerFindRoute = (router: IRouter) => {
         fields: typeof query.fields === 'string' ? [query.fields] : query.fields,
         filter: query.filter,
         namespaces,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/import.ts
+++ b/src/core/server/saved_objects/routes/import.ts
@@ -60,6 +60,9 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
           {
             overwrite: schema.boolean({ defaultValue: false }),
             createNewCopies: schema.boolean({ defaultValue: false }),
+            workspaces: schema.maybe(
+              schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+            ),
           },
           {
             validate: (object) => {
@@ -91,6 +94,11 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         });
       }
 
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+
       const result = await importSavedObjectsFromStream({
         savedObjectsClient: context.core.savedObjects.client,
         typeRegistry: context.core.savedObjects.typeRegistry,
@@ -98,6 +106,7 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         objectLimit: maxImportExportSize,
         overwrite,
         createNewCopies,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/integration_tests/find.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/find.test.ts
@@ -288,4 +288,38 @@ describe('GET /api/saved_objects/_find', () => {
       defaultSearchOperator: 'OR',
     });
   });
+
+  it('accepts the query parameter workspaces as a string', async () => {
+    await supertest(httpSetup.server.listener)
+      .get('/api/saved_objects/_find?type=index-pattern&workspaces=foo')
+      .expect(200);
+
+    expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
+
+    const options = savedObjectsClient.find.mock.calls[0][0];
+    expect(options).toEqual({
+      defaultSearchOperator: 'OR',
+      perPage: 20,
+      page: 1,
+      type: ['index-pattern'],
+      workspaces: ['foo'],
+    });
+  });
+
+  it('accepts the query parameter workspaces as an array', async () => {
+    await supertest(httpSetup.server.listener)
+      .get('/api/saved_objects/_find?type=index-pattern&workspaces=default&workspaces=foo')
+      .expect(200);
+
+    expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
+
+    const options = savedObjectsClient.find.mock.calls[0][0];
+    expect(options).toEqual({
+      perPage: 20,
+      page: 1,
+      type: ['index-pattern'],
+      workspaces: ['default', 'foo'],
+      defaultSearchOperator: 'OR',
+    });
+  });
 });

--- a/src/core/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/routes/resolve_import_errors.ts
@@ -58,6 +58,9 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
       validate: {
         query: schema.object({
           createNewCopies: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
         body: schema.object({
           file: schema.stream(),
@@ -98,6 +101,11 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         });
       }
 
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+
       const result = await resolveSavedObjectsImportErrors({
         typeRegistry: context.core.savedObjects.typeRegistry,
         savedObjectsClient: context.core.savedObjects.client,
@@ -105,6 +113,7 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         retries: req.body.retries,
         objectLimit: maxImportExportSize,
         createNewCopies: req.query.createNewCopies,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/serialization/serializer.ts
+++ b/src/core/server/saved_objects/serialization/serializer.ts
@@ -73,7 +73,7 @@ export class SavedObjectsSerializer {
    */
   public rawToSavedObject(doc: SavedObjectsRawDoc): SavedObjectSanitizedDoc {
     const { _id, _source, _seq_no, _primary_term } = doc;
-    const { type, namespace, namespaces, originId } = _source;
+    const { type, namespace, namespaces, originId, workspaces } = _source;
 
     const version =
       _seq_no != null || _primary_term != null
@@ -91,6 +91,7 @@ export class SavedObjectsSerializer {
       ...(_source.migrationVersion && { migrationVersion: _source.migrationVersion }),
       ...(_source.updated_at && { updated_at: _source.updated_at }),
       ...(version && { version }),
+      ...(workspaces && { workspaces }),
     };
   }
 
@@ -112,6 +113,7 @@ export class SavedObjectsSerializer {
       updated_at,
       version,
       references,
+      workspaces,
     } = savedObj;
     const source = {
       [type]: attributes,
@@ -122,6 +124,7 @@ export class SavedObjectsSerializer {
       ...(originId && { originId }),
       ...(migrationVersion && { migrationVersion }),
       ...(updated_at && { updated_at }),
+      ...(workspaces && { workspaces }),
     };
 
     return {

--- a/src/core/server/saved_objects/serialization/types.ts
+++ b/src/core/server/saved_objects/serialization/types.ts
@@ -52,6 +52,7 @@ export interface SavedObjectsRawDocSource {
   updated_at?: string;
   references?: SavedObjectReference[];
   originId?: string;
+  workspaces?: string[];
 
   [typeMapping: string]: any;
 }
@@ -69,6 +70,7 @@ interface SavedObjectDoc<T = unknown> {
   version?: string;
   updated_at?: string;
   originId?: string;
+  workspaces?: string[];
 }
 
 interface Referencable {

--- a/src/core/server/saved_objects/service/lib/integration_tests/repository.test.ts
+++ b/src/core/server/saved_objects/service/lib/integration_tests/repository.test.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SavedObject } from 'src/core/types';
+import { isEqual } from 'lodash';
+import * as osdTestServer from '../../../../../test_helpers/osd_server';
+import { Readable } from 'stream';
+
+const dashboard: Omit<SavedObject, 'id'> = {
+  type: 'dashboard',
+  attributes: {},
+  references: [],
+};
+
+describe('repository integration test', () => {
+  let root: ReturnType<typeof osdTestServer.createRoot>;
+  let opensearchServer: osdTestServer.TestOpenSearchUtils;
+  beforeAll(async () => {
+    const { startOpenSearch, startOpenSearchDashboards } = osdTestServer.createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+    });
+    opensearchServer = await startOpenSearch();
+    const startOSDResp = await startOpenSearchDashboards();
+    root = startOSDResp.root;
+  }, 30000);
+  afterAll(async () => {
+    await root.shutdown();
+    await opensearchServer.stop();
+  });
+
+  const deleteItem = async (object: Pick<SavedObject, 'id' | 'type'>) => {
+    expect(
+      [200, 404].includes(
+        (await osdTestServer.request.delete(root, `/api/saved_objects/${object.type}/${object.id}`))
+          .statusCode
+      )
+    );
+  };
+
+  const getItem = async (object: Pick<SavedObject, 'id' | 'type'>) => {
+    return await osdTestServer.request
+      .get(root, `/api/saved_objects/${object.type}/${object.id}`)
+      .expect(200);
+  };
+
+  const clearFooAndBar = async () => {
+    await deleteItem({
+      type: dashboard.type,
+      id: 'foo',
+    });
+    await deleteItem({
+      type: dashboard.type,
+      id: 'bar',
+    });
+  };
+
+  describe('workspace related CRUD', () => {
+    it('create', async () => {
+      const createResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['foo'],
+        })
+        .expect(200);
+
+      expect(createResult.body.workspaces).toEqual(['foo']);
+      await deleteItem({
+        type: dashboard.type,
+        id: createResult.body.id,
+      });
+    });
+
+    it('create-with-override', async () => {
+      const createResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['foo'],
+        })
+        .expect(200);
+
+      await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}/${createResult.body.id}?overwrite=true`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['bar'],
+        })
+        .expect(409);
+
+      await deleteItem({
+        type: dashboard.type,
+        id: createResult.body.id,
+      });
+    });
+
+    it('bulk create', async () => {
+      await clearFooAndBar();
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      expect((createResultFoo.body.saved_objects as any[]).some((item) => item.error)).toEqual(
+        false
+      );
+      expect(
+        (createResultFoo.body.saved_objects as any[]).every((item) =>
+          isEqual(item.workspaces, ['foo'])
+        )
+      ).toEqual(true);
+      expect((createResultBar.body.saved_objects as any[]).some((item) => item.error)).toEqual(
+        false
+      );
+      expect(
+        (createResultBar.body.saved_objects as any[]).every((item) =>
+          isEqual(item.workspaces, ['bar'])
+        )
+      ).toEqual(true);
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('bulk create with conflict', async () => {
+      await clearFooAndBar();
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      /**
+       * overwrite with workspaces
+       */
+      const overwriteWithWorkspacesResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?overwrite=true&workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+          {
+            ...dashboard,
+            id: 'foo',
+            attributes: {
+              title: 'foo',
+            },
+          },
+        ])
+        .expect(200);
+
+      expect(overwriteWithWorkspacesResult.body.saved_objects[0].error.statusCode).toEqual(409);
+      expect(overwriteWithWorkspacesResult.body.saved_objects[1].attributes.title).toEqual('foo');
+      expect(overwriteWithWorkspacesResult.body.saved_objects[1].workspaces).toEqual(['foo']);
+
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('checkConflicts when importing ndjson', async () => {
+      await clearFooAndBar();
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      const getResultFoo = await getItem({
+        type: dashboard.type,
+        id: 'foo',
+      });
+      const getResultBar = await getItem({
+        type: dashboard.type,
+        id: 'bar',
+      });
+
+      const readableStream = new Readable();
+      readableStream.push(
+        `Content-Disposition: form-data; name="file"; filename="tmp.ndjson"\r\n\r\n`
+      );
+      readableStream.push(
+        [JSON.stringify(getResultFoo.body), JSON.stringify(getResultBar.body)].join('\n')
+      );
+      readableStream.push(null);
+
+      /**
+       * import with workspaces when conflicts
+       */
+      const importWithWorkspacesResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/_import?workspaces=foo&overwrite=false`)
+        .attach(
+          'file',
+          Buffer.from(
+            [JSON.stringify(getResultFoo.body), JSON.stringify(getResultBar.body)].join('\n'),
+            'utf-8'
+          ),
+          'tmp.ndjson'
+        )
+        .expect(200);
+
+      expect(importWithWorkspacesResult.body.success).toEqual(false);
+      expect(importWithWorkspacesResult.body.errors.length).toEqual(1);
+      expect(importWithWorkspacesResult.body.errors[0].id).toEqual('foo');
+      expect(importWithWorkspacesResult.body.errors[0].error.type).toEqual('conflict');
+
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('find by workspaces', async () => {
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      const findResult = await osdTestServer.request
+        .get(root, `/api/saved_objects/_find?workspaces=bar&type=${dashboard.type}`)
+        .expect(200);
+
+      expect(findResult.body.total).toEqual(1);
+      expect(findResult.body.saved_objects[0].workspaces).toEqual(['bar']);
+
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+  });
+});

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -27,7 +27,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+import { omit } from 'lodash';
 import { SavedObjectsRepository } from './repository';
 import * as getSearchDslNS from './search_dsl/search_dsl';
 import { SavedObjectsErrorHelpers } from './errors';
@@ -168,7 +168,7 @@ describe('SavedObjectsRepository', () => {
   });
 
   const getMockGetResponse = (
-    { type, id, references, namespace: objectNamespace, originId },
+    { type, id, references, namespace: objectNamespace, originId, workspaces },
     namespace
   ) => {
     const namespaceId = objectNamespace === 'default' ? undefined : objectNamespace ?? namespace;
@@ -182,6 +182,7 @@ describe('SavedObjectsRepository', () => {
       _source: {
         ...(registry.isSingleNamespace(type) && { namespace: namespaceId }),
         ...(registry.isMultiNamespace(type) && { namespaces: [namespaceId ?? 'default'] }),
+        workspaces,
         ...(originId && { originId }),
         type,
         [type]: { title: 'Testing' },
@@ -444,6 +445,7 @@ describe('SavedObjectsRepository', () => {
       references: [{ name: 'ref_0', type: 'test', id: '2' }],
     };
     const namespace = 'foo-namespace';
+    const workspace = 'foo-workspace';
 
     const getMockBulkCreateResponse = (objects, namespace) => {
       return {
@@ -480,7 +482,9 @@ describe('SavedObjectsRepository', () => {
         opensearchClientMock.createSuccessTransportRequestPromise(response)
       );
       const result = await savedObjectsRepository.bulkCreate(objects, options);
-      expect(client.mget).toHaveBeenCalledTimes(multiNamespaceObjects?.length ? 1 : 0);
+      expect(client.mget).toHaveBeenCalledTimes(
+        multiNamespaceObjects?.length || options?.workspaces ? 1 : 0
+      );
       return result;
     };
 
@@ -683,6 +687,7 @@ describe('SavedObjectsRepository', () => {
             expect.anything()
           );
           client.bulk.mockClear();
+          client.mget.mockClear();
         };
         await test(undefined);
         await test(namespace);
@@ -729,6 +734,16 @@ describe('SavedObjectsRepository', () => {
         ];
         await bulkCreateSuccess(objects, { namespace });
         expectClientCallArgsAction(objects, { method: 'create', getId });
+      });
+
+      it(`adds workspaces to request body for any types`, async () => {
+        await bulkCreateSuccess([obj1, obj2], { workspaces: [workspace] });
+        const expected = expect.objectContaining({ workspaces: [workspace] });
+        const body = [expect.any(Object), expected, expect.any(Object), expected];
+        expect(client.bulk).toHaveBeenCalledWith(
+          expect.objectContaining({ body }),
+          expect.anything()
+        );
       });
     });
 
@@ -876,6 +891,74 @@ describe('SavedObjectsRepository', () => {
         const opensearchError = { foo: 'some_other_error' };
         const expectedError = expectErrorResult(obj3, { message: JSON.stringify(opensearchError) });
         await bulkCreateError(obj3, opensearchError, expectedError);
+      });
+
+      it(`returns error when there is a conflict with an existing saved object according to workspaces`, async () => {
+        const obj = { ...obj3, workspaces: ['foo'] };
+        const response1 = {
+          status: 200,
+          docs: [
+            {
+              found: true,
+              _id: `${obj1.type}:${obj1.id}`,
+              _source: {
+                type: obj1.type,
+                workspaces: ['bar'],
+              },
+            },
+            {
+              found: true,
+              _id: `${obj.type}:${obj.id}`,
+              _source: {
+                type: obj.type,
+                workspaces: obj.workspaces,
+              },
+            },
+            {
+              found: true,
+              _id: `${obj2.type}:${obj2.id}`,
+              _source: {
+                type: obj2.type,
+              },
+            },
+          ],
+        };
+        client.mget.mockResolvedValueOnce(
+          opensearchClientMock.createSuccessTransportRequestPromise(response1)
+        );
+        const response2 = getMockBulkCreateResponse([obj1, obj, obj2]);
+        client.bulk.mockResolvedValueOnce(
+          opensearchClientMock.createSuccessTransportRequestPromise(response2)
+        );
+
+        const options = { overwrite: true, workspaces: ['bar'] };
+        const result = await savedObjectsRepository.bulkCreate([obj1, obj, obj2], options);
+        expect(client.bulk).toHaveBeenCalled();
+        expect(client.mget).toHaveBeenCalled();
+
+        const body1 = {
+          docs: [
+            expect.objectContaining({ _id: `${obj1.type}:${obj1.id}` }),
+            expect.objectContaining({ _id: `${obj.type}:${obj.id}` }),
+            expect.objectContaining({ _id: `${obj2.type}:${obj2.id}` }),
+          ],
+        };
+        expect(client.mget).toHaveBeenCalledWith(
+          expect.objectContaining({ body: body1 }),
+          expect.anything()
+        );
+        const body2 = [...expectObjArgs(obj1)];
+        expect(client.bulk).toHaveBeenCalledWith(
+          expect.objectContaining({ body: body2 }),
+          expect.anything()
+        );
+        expect(result).toEqual({
+          saved_objects: [
+            expectSuccess(obj1),
+            expectErrorConflict(obj, { metadata: { isNotOverwritable: true } }),
+            expectErrorConflict(obj2, { metadata: { isNotOverwritable: true } }),
+          ],
+        });
       });
     });
 
@@ -1699,6 +1782,8 @@ describe('SavedObjectsRepository', () => {
     const obj5 = { type: MULTI_NAMESPACE_TYPE, id: 'five' };
     const obj6 = { type: NAMESPACE_AGNOSTIC_TYPE, id: 'six' };
     const obj7 = { type: NAMESPACE_AGNOSTIC_TYPE, id: 'seven' };
+    const obj8 = { type: 'dashboard', id: 'eight', workspaces: ['foo'] };
+    const obj9 = { type: 'dashboard', id: 'nine', workspaces: ['bar'] };
     const namespace = 'foo-namespace';
 
     const checkConflicts = async (objects, options) =>
@@ -1790,6 +1875,8 @@ describe('SavedObjectsRepository', () => {
             { found: false },
             getMockGetResponse(obj6),
             { found: false },
+            getMockGetResponse(obj7),
+            getMockGetResponse(obj8),
           ],
         };
         client.mget.mockResolvedValue(
@@ -1815,6 +1902,36 @@ describe('SavedObjectsRepository', () => {
             // obj5 was not found so it does not result in a conflict error
             { ...obj6, error: createConflictError(obj6.type, obj6.id) },
             // obj7 was not found so it does not result in a conflict error
+          ],
+        });
+      });
+
+      it(`expected results with workspaces`, async () => {
+        const objects = [obj8, obj9];
+        const response = {
+          status: 200,
+          docs: [getMockGetResponse(obj8), getMockGetResponse(obj9)],
+        };
+        client.mget.mockResolvedValue(
+          opensearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+
+        const result = await checkConflicts(objects, {
+          workspaces: ['foo'],
+        });
+        expect(client.mget).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+          errors: [
+            { ...omit(obj8, 'workspaces'), error: createConflictError(obj8.type, obj8.id) },
+            {
+              ...omit(obj9, 'workspaces'),
+              error: {
+                ...createConflictError(obj9.type, obj9.id),
+                metadata: {
+                  isNotOverwritable: true,
+                },
+              },
+            },
           ],
         });
       });
@@ -1846,9 +1963,17 @@ describe('SavedObjectsRepository', () => {
 
     const createSuccess = async (type, attributes, options) => {
       const result = await savedObjectsRepository.create(type, attributes, options);
-      expect(client.get).toHaveBeenCalledTimes(
-        registry.isMultiNamespace(type) && options.overwrite ? 1 : 0
-      );
+      let count = 0;
+      if (options?.overwrite && options.id && options.workspaces) {
+        /**
+         * workspace will call extra one to get latest status of current object
+         */
+        count++;
+      }
+      if (registry.isMultiNamespace(type) && options.overwrite) {
+        count++;
+      }
+      expect(client.get).toHaveBeenCalledTimes(count);
       return result;
     };
 
@@ -2040,6 +2165,29 @@ describe('SavedObjectsRepository', () => {
           expect.anything()
         );
       });
+
+      it(`doesn't modify workspaces when overwrite without target workspaces`, async () => {
+        const response = getMockGetResponse({ workspaces: ['foo'], id });
+        client.get.mockResolvedValueOnce(
+          opensearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+
+        await savedObjectsRepository.create('dashboard', attributes, {
+          id,
+          overwrite: true,
+          workspaces: [],
+        });
+
+        expect(client.index).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: `dashboard:${id}`,
+            body: expect.objectContaining({
+              workspaces: ['foo'],
+            }),
+          }),
+          expect.anything()
+        );
+      });
     });
 
     describe('errors', () => {
@@ -2097,6 +2245,21 @@ describe('SavedObjectsRepository', () => {
             namespace,
           })
         ).rejects.toThrowError(createConflictError(MULTI_NAMESPACE_TYPE, id));
+        expect(client.get).toHaveBeenCalled();
+      });
+
+      it(`throws error when there is a conflict with an existing workspaces saved object`, async () => {
+        const response = getMockGetResponse({ workspaces: ['foo'], id });
+        client.get.mockResolvedValueOnce(
+          opensearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+        await expect(
+          savedObjectsRepository.create('dashboard', attributes, {
+            id,
+            overwrite: true,
+            workspaces: ['bar'],
+          })
+        ).rejects.toThrowError(createConflictError('dashboard', id));
         expect(client.get).toHaveBeenCalled();
       });
 
@@ -2186,10 +2349,11 @@ describe('SavedObjectsRepository', () => {
     const type = 'index-pattern';
     const id = 'logstash-*';
     const namespace = 'foo-namespace';
+    const workspaces = ['bar-workspace'];
 
     const deleteSuccess = async (type, id, options) => {
       if (registry.isMultiNamespace(type)) {
-        const mockGetResponse = getMockGetResponse({ type, id }, options?.namespace);
+        const mockGetResponse = getMockGetResponse({ type, id }, options?.namespace, workspaces);
         client.get.mockResolvedValueOnce(
           opensearchClientMock.createSuccessTransportRequestPromise(mockGetResponse)
         );

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -27,7 +27,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
 import { SavedObjectsRepository } from './repository';
 import * as getSearchDslNS from './search_dsl/search_dsl';
 import { SavedObjectsErrorHelpers } from './errors';
@@ -53,6 +52,12 @@ const createGenericNotFoundError = (...args) =>
   SavedObjectsErrorHelpers.createGenericNotFoundError(...args).output.payload;
 const createUnsupportedTypeError = (...args) =>
   SavedObjectsErrorHelpers.createUnsupportedTypeError(...args).output.payload;
+
+const omitWorkspace = (object) => {
+  const newObject = JSON.parse(JSON.stringify(object));
+  delete newObject.workspaces;
+  return newObject;
+};
 
 describe('SavedObjectsRepository', () => {
   let client;
@@ -1922,9 +1927,9 @@ describe('SavedObjectsRepository', () => {
         expect(client.mget).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
           errors: [
-            { ...omit(obj8, 'workspaces'), error: createConflictError(obj8.type, obj8.id) },
+            { ...omitWorkspace(obj8), error: createConflictError(obj8.type, obj8.id) },
             {
-              ...omit(obj9, 'workspaces'),
+              ...omitWorkspace(obj9),
               error: {
                 ...createConflictError(obj9.type, obj9.id),
                 metadata: {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -383,7 +383,7 @@ export class SavedObjectsRepository {
       /**
        * It requires a check when overwriting objects to target workspaces
        */
-      const requiresWorkspaceCheck = !!(object.id && overwrite && options.workspaces);
+      const requiresWorkspaceCheck = !!(object.id && options.workspaces);
 
       if (object.id == null) object.id = uuid.v1();
 

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
@@ -625,6 +625,27 @@ describe('#getQueryParams', () => {
         ]);
       });
     });
+
+    describe('when using workspace search', () => {
+      it('using normal workspaces', () => {
+        const result: Result = getQueryParams({
+          registry,
+          workspaces: ['foo'],
+        });
+        expect(result.query.bool.filter[1]).toEqual({
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [{ term: { workspaces: 'foo' } }],
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        });
+      });
+    });
   });
 
   describe('namespaces property', () => {

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -131,14 +131,8 @@ function getClauseForType(
  *  Gets the clause that will filter for the workspace.
  */
 function getClauseForWorkspace(workspace: string) {
-  if (workspace === '*') {
-    return {
-      bool: {
-        must: {
-          match_all: {},
-        },
-      },
-    };
+  if (!workspace) {
+    return {};
   }
 
   return {
@@ -246,12 +240,14 @@ export function getQueryParams({
     ],
   };
 
-  if (workspaces) {
+  if (workspaces?.filter((workspace) => workspace).length) {
     bool.filter.push({
       bool: {
-        should: workspaces.map((workspace) => {
-          return getClauseForWorkspace(workspace);
-        }),
+        should: workspaces
+          .filter((workspace) => workspace)
+          .map((workspace) => {
+            return getClauseForWorkspace(workspace);
+          }),
         minimum_should_match: 1,
       },
     });

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -127,6 +127,26 @@ function getClauseForType(
     },
   };
 }
+/**
+ *  Gets the clause that will filter for the workspace.
+ */
+function getClauseForWorkspace(workspace: string) {
+  if (workspace === '*') {
+    return {
+      bool: {
+        must: {
+          match_all: {},
+        },
+      },
+    };
+  }
+
+  return {
+    bool: {
+      must: [{ term: { workspaces: workspace } }],
+    },
+  };
+}
 
 interface HasReferenceQueryParams {
   type: string;
@@ -144,6 +164,7 @@ interface QueryParams {
   defaultSearchOperator?: string;
   hasReference?: HasReferenceQueryParams;
   kueryNode?: KueryNode;
+  workspaces?: string[];
 }
 
 export function getClauseForReference(reference: HasReferenceQueryParams) {
@@ -200,6 +221,7 @@ export function getQueryParams({
   defaultSearchOperator,
   hasReference,
   kueryNode,
+  workspaces,
 }: QueryParams) {
   const types = getTypes(
     registry,
@@ -223,6 +245,17 @@ export function getQueryParams({
       },
     ],
   };
+
+  if (workspaces) {
+    bool.filter.push({
+      bool: {
+        should: workspaces.map((workspace) => {
+          return getClauseForWorkspace(workspace);
+        }),
+        minimum_should_match: 1,
+      },
+    });
+  }
 
   if (search) {
     const useMatchPhrasePrefix = shouldUseMatchPhrasePrefix(search);

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -52,6 +52,7 @@ interface GetSearchDslOptions {
     id: string;
   };
   kueryNode?: KueryNode;
+  workspaces?: string[];
 }
 
 export function getSearchDsl(
@@ -71,6 +72,7 @@ export function getSearchDsl(
     typeToNamespacesMap,
     hasReference,
     kueryNode,
+    workspaces,
   } = options;
 
   if (!type) {
@@ -93,6 +95,7 @@ export function getSearchDsl(
       defaultSearchOperator,
       hasReference,
       kueryNode,
+      workspaces,
     }),
     ...getSortingParams(mappings, type, sortField, sortOrder),
   };

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -83,8 +83,8 @@ export class SavedObjectsUtils {
 
   public static filterWorkspacesAccordingToBaseWorkspaces(
     targetWorkspaces?: string[],
-    baseWorkspaces?: string[]
+    sourceWorkspaces?: string[]
   ): string[] {
-    return targetWorkspaces?.filter((item) => !baseWorkspaces?.includes(item)) || [];
+    return targetWorkspaces?.filter((item) => !sourceWorkspaces?.includes(item)) || [];
   }
 }

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -80,4 +80,11 @@ export class SavedObjectsUtils {
     total: 0,
     saved_objects: [],
   });
+
+  public static filterWorkspacesAccordingToBaseWorkspaces(
+    targetWorkspaces?: string[],
+    baseWorkspaces?: string[]
+  ): string[] {
+    return targetWorkspaces?.filter((item) => !baseWorkspaces?.includes(item)) || [];
+  }
 }

--- a/src/core/server/saved_objects/service/saved_objects_client.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.ts
@@ -363,7 +363,7 @@ export class SavedObjectsClient {
    */
   async bulkGet<T = unknown>(
     objects: SavedObjectsBulkGetObject[] = [],
-    options: SavedObjectsBaseOptions = {}
+    options: Omit<SavedObjectsBaseOptions, 'workspaces'> = {}
   ): Promise<SavedObjectsBulkResponse<T>> {
     return await this._repository.bulkGet(objects, options);
   }

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -110,6 +110,7 @@ export interface SavedObjectsFindOptions {
   typeToNamespacesMap?: Map<string, string[] | undefined>;
   /** An optional OpenSearch preference value to be used for the query **/
   preference?: string;
+  /** If specified, will find all objects belong to specified workspaces **/
   workspaces?: string[];
 }
 
@@ -120,6 +121,7 @@ export interface SavedObjectsFindOptions {
 export interface SavedObjectsBaseOptions {
   /** Specify the namespace for this operation */
   namespace?: string;
+  /** Specify the workspaces for this operation */
   workspaces?: string[];
 }
 

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -110,6 +110,7 @@ export interface SavedObjectsFindOptions {
   typeToNamespacesMap?: Map<string, string[] | undefined>;
   /** An optional OpenSearch preference value to be used for the query **/
   preference?: string;
+  workspaces?: string[];
 }
 
 /**
@@ -119,6 +120,7 @@ export interface SavedObjectsFindOptions {
 export interface SavedObjectsBaseOptions {
   /** Specify the namespace for this operation */
   namespace?: string;
+  workspaces?: string[];
 }
 
 /**

--- a/src/core/types/saved_objects.ts
+++ b/src/core/types/saved_objects.ts
@@ -113,6 +113,7 @@ export interface SavedObject<T = unknown> {
    * space.
    */
   originId?: string;
+  /** Workspaces that this saved object exists in. */
   workspaces?: string[];
 }
 

--- a/src/core/types/saved_objects.ts
+++ b/src/core/types/saved_objects.ts
@@ -113,6 +113,7 @@ export interface SavedObject<T = unknown> {
    * space.
    */
   originId?: string;
+  workspaces?: string[];
 }
 
 export interface SavedObjectError {


### PR DESCRIPTION
### Description

The main change of this PR are:
1. Add `workspaces`  field to the mappings of the OSD index(.kibana)
2. Add optional `workspaces` parameter to all the saved objects API
3. Update some test snapshot because of the above change.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
