### PR TITLE
Add integration test for workspace saved objects client wrapper

### DIFF
--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -145,7 +145,7 @@ function getClauseForWorkspace(workspace: string) {
 
   return {
     bool: {
-      must: [{ term: { 'workspaces.keyword': workspace } }],
+      must: [{ term: { workspaces: workspace } }],
     },
   };
 }
@@ -297,7 +297,7 @@ export function getQueryParams({
     if (ACLSearchParams.workspaces) {
       shouldClause.push({
         terms: {
-          'workspaces.keyword': ACLSearchParams.workspaces,
+          workspaces: ACLSearchParams.workspaces,
         },
       });
     }

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -145,7 +145,7 @@ function getClauseForWorkspace(workspace: string) {
 
   return {
     bool: {
-      must: [{ term: { workspaces: workspace } }],
+      must: [{ term: { 'workspaces.keyword': workspace } }],
     },
   };
 }
@@ -297,7 +297,7 @@ export function getQueryParams({
     if (ACLSearchParams.workspaces) {
       shouldClause.push({
         terms: {
-          workspaces: ACLSearchParams.workspaces,
+          'workspaces.keyword': ACLSearchParams.workspaces,
         },
       });
     }

--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -132,7 +132,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
     await repositoryKit.clearAll(internalSavedObjectsRepository);
     await opensearchServer.stop();
     await osd.stop();
-  }, 30000);
+  });
 
   beforeEach(() => {
     jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
@@ -166,7 +166,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
       }
       expect(error).not.toBeUndefined();
       expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
-    }, 30000);
+    });
 
     it('should return consistent dashboard when user permitted', async () => {
       jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
@@ -182,7 +182,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
       expect(
         (await savedObjectsClient.get('dashboard', 'acl-controlled-dashboard-2')).error
       ).toBeUndefined();
-    }, 30000);
+    });
   });
 
   describe('bulkGet', () => {
@@ -209,7 +209,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
       }
       expect(error).not.toBeUndefined();
       expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
-    }, 30000);
+    });
 
     it('should return consistent dashboard when user permitted', async () => {
       jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
@@ -233,7 +233,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           ])
         ).saved_objects.length
       ).toEqual(1);
-    }, 30000);
+    });
   });
 
   describe('find', () => {

--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -1,0 +1,704 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ISavedObjectsRepository } from 'src/core/server';
+
+import {
+  createTestServers,
+  TestOpenSearchUtils,
+  TestOpenSearchDashboardsUtils,
+  TestUtils,
+} from '../../../../../core/test_helpers/osd_server';
+import { SavedObjectsErrorHelpers } from '../../../../../core/server';
+import { httpServerMock } from '../../../../../../src/core/server/mocks';
+import * as utilsExports from '../../utils';
+
+const repositoryKit = (() => {
+  const savedObjects: Array<{ type: string; id: string }> = [];
+  return {
+    create: async (
+      repository: ISavedObjectsRepository,
+      ...params: Parameters<ISavedObjectsRepository['create']>
+    ) => {
+      let result;
+      try {
+        result = params[2]?.id ? await repository.get(params[0], params[2].id) : undefined;
+      } catch (_e) {
+        // ignore error when get failed
+      }
+      if (!result) {
+        result = await repository.create(...params);
+      }
+      savedObjects.push(result);
+      return result;
+    },
+    clearAll: async (repository: ISavedObjectsRepository) => {
+      for (let i = 0; i < savedObjects.length; i++) {
+        await repository.delete(savedObjects[i].type, savedObjects[i].id);
+      }
+    },
+  };
+})();
+
+describe('WorkspaceSavedObjectsClientWrapper', () => {
+  let internalSavedObjectsRepository: ISavedObjectsRepository;
+  let servers: TestUtils;
+  let opensearchServer: TestOpenSearchUtils;
+  let osd: TestOpenSearchDashboardsUtils;
+
+  beforeAll(async function () {
+    servers = createTestServers({
+      adjustTimeout: (t) => {
+        jest.setTimeout(t);
+      },
+      settings: {
+        osd: {
+          workspace: {
+            enabled: true,
+          },
+        },
+      },
+    });
+    opensearchServer = await servers.startOpenSearch();
+    osd = await servers.startOpenSearchDashboards();
+
+    internalSavedObjectsRepository = osd.coreStart.savedObjects.createInternalRepository();
+
+    await repositoryKit.create(
+      internalSavedObjectsRepository,
+      'workspace',
+      {},
+      {
+        id: 'workspace-1',
+        permissions: {
+          library_read: { users: ['foo'] },
+          library_write: { users: ['foo'] },
+        },
+      }
+    );
+
+    await repositoryKit.create(
+      internalSavedObjectsRepository,
+      'dashboard',
+      {},
+      {
+        id: 'inner-workspace-dashboard-1',
+        workspaces: ['workspace-1'],
+      }
+    );
+
+    await repositoryKit.create(
+      internalSavedObjectsRepository,
+      'dashboard',
+      {},
+      {
+        id: 'acl-controlled-dashboard-2',
+        permissions: {
+          read: { users: ['foo'], groups: [] },
+          write: { users: ['foo'], groups: [] },
+        },
+      }
+    );
+  });
+
+  afterAll(async () => {
+    await repositoryKit.clearAll(internalSavedObjectsRepository);
+    await opensearchServer.stop();
+    await osd.stop();
+  }, 30000);
+
+  beforeEach(() => {
+    jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+      users: ['bar'],
+    });
+  });
+
+  afterEach(() => {
+    jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockRestore();
+  });
+
+  describe('get', () => {
+    it('should throw forbidden error when user not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.get('dashboard', 'inner-workspace-dashboard-1');
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.toBeUndefined();
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+
+      error = undefined;
+      try {
+        await savedObjectsClient.get('dashboard', 'acl-controlled-dashboard-2');
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.toBeUndefined();
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    }, 30000);
+
+    it('should return consistent dashboard when user permitted', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      expect(
+        (await savedObjectsClient.get('dashboard', 'inner-workspace-dashboard-1')).error
+      ).toBeUndefined();
+      expect(
+        (await savedObjectsClient.get('dashboard', 'acl-controlled-dashboard-2')).error
+      ).toBeUndefined();
+    }, 30000);
+  });
+
+  describe('bulkGet', () => {
+    it('should throw forbidden error when user not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.bulkGet([
+          { type: 'dashboard', id: 'inner-workspace-dashboard-1' },
+        ]);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.toBeUndefined();
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+
+      error = undefined;
+      try {
+        await savedObjectsClient.bulkGet([{ type: 'dashboard', id: 'acl-controlled-dashboard-2' }]);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.toBeUndefined();
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    }, 30000);
+
+    it('should return consistent dashboard when user permitted', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      expect(
+        (
+          await savedObjectsClient.bulkGet([
+            { type: 'dashboard', id: 'inner-workspace-dashboard-1' },
+          ])
+        ).saved_objects.length
+      ).toEqual(1);
+      expect(
+        (
+          await savedObjectsClient.bulkGet([
+            { type: 'dashboard', id: 'acl-controlled-dashboard-2' },
+          ])
+        ).saved_objects.length
+      ).toEqual(1);
+    }, 30000);
+  });
+
+  describe('find', () => {
+    it('should throw not authorized error when user not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.find({
+          type: 'dashboard',
+          workspaces: ['workspace-1'],
+          perPage: 999,
+          page: 1,
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isNotAuthorizedError(error)).toBe(true);
+    });
+
+    it('should return consistent inner workspace data when user permitted', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      const result = await savedObjectsClient.find({
+        type: 'dashboard',
+        workspaces: ['workspace-1'],
+        perPage: 999,
+        page: 1,
+      });
+
+      expect(result.saved_objects.some((item) => item.id === 'inner-workspace-dashboard-1')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('should throw forbidden error when workspace not permitted and create called', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.create(
+          'dashboard',
+          {},
+          {
+            workspaces: ['workspace-1'],
+          }
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should able to create saved objects into permitted workspaces after create called', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      const createResult = await savedObjectsClient.create(
+        'dashboard',
+        {},
+        {
+          workspaces: ['workspace-1'],
+        }
+      );
+      expect(createResult.error).toBeUndefined();
+      await savedObjectsClient.delete('dashboard', createResult.id);
+    });
+
+    it('should throw forbidden error when create with override', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.create(
+          'dashboard',
+          {},
+          {
+            id: 'inner-workspace-dashboard-1',
+            overwrite: true,
+          }
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+  });
+
+  describe('bulkCreate', () => {
+    it('should throw forbidden error when workspace not permitted and bulkCreate called', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.bulkCreate([{ type: 'dashboard', attributes: {} }], {
+          workspaces: ['workspace-1'],
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should able to create saved objects into permitted workspaces after bulkCreate called', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      const objectId = new Date().getTime().toString(16).toUpperCase();
+      const result = await savedObjectsClient.bulkCreate(
+        [{ type: 'dashboard', attributes: {}, id: objectId }],
+        {
+          workspaces: ['workspace-1'],
+        }
+      );
+      expect(result.saved_objects.length).toEqual(1);
+      await savedObjectsClient.delete('dashboard', objectId);
+    });
+  });
+
+  describe('update', () => {
+    it('should throw forbidden error when data not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.update('dashboard', 'inner-workspace-dashboard-1', {});
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+
+      error = undefined;
+      try {
+        await savedObjectsClient.update('dashboard', 'acl-controlled-dashboard-2', {});
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should update saved objects for permitted workspaces', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      expect(
+        (await savedObjectsClient.update('dashboard', 'inner-workspace-dashboard-1', {})).error
+      ).toBeUndefined();
+      expect(
+        (await savedObjectsClient.update('dashboard', 'acl-controlled-dashboard-2', {})).error
+      ).toBeUndefined();
+    });
+  });
+
+  describe('bulkUpdate', () => {
+    it('should throw forbidden error when data not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.bulkUpdate(
+          [{ type: 'dashboard', id: 'inner-workspace-dashboard-1', attributes: {} }],
+          {}
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+
+      error = undefined;
+      try {
+        await savedObjectsClient.bulkUpdate(
+          [{ type: 'dashboard', id: 'acl-controlled-dashboard-2', attributes: {} }],
+          {}
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should bulk update saved objects for permitted workspaces', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      expect(
+        (
+          await savedObjectsClient.bulkUpdate([
+            { type: 'dashboard', id: 'inner-workspace-dashboard-1', attributes: {} },
+          ])
+        ).saved_objects.length
+      ).toEqual(1);
+      expect(
+        (
+          await savedObjectsClient.bulkUpdate([
+            { type: 'dashboard', id: 'inner-workspace-dashboard-1', attributes: {} },
+          ])
+        ).saved_objects.length
+      ).toEqual(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('should throw forbidden error when data not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.delete('dashboard', 'inner-workspace-dashboard-1');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+
+      error = undefined;
+      try {
+        await savedObjectsClient.delete('dashboard', 'acl-controlled-dashboard-2');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should be able to delete permitted data', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      const createResult = await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'dashboard',
+        {},
+        {
+          workspaces: ['workspace-1'],
+        }
+      );
+
+      await savedObjectsClient.delete('dashboard', createResult.id);
+
+      let error;
+      try {
+        error = await savedObjectsClient.get('dashboard', createResult.id);
+      } catch (e) {
+        error = e;
+      }
+      expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(true);
+    });
+
+    it('should be able to delete acl controlled permitted data', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      const createResult = await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'dashboard',
+        {},
+        {
+          permissions: {
+            read: { users: ['foo'] },
+            write: { users: ['foo'] },
+          },
+        }
+      );
+
+      await savedObjectsClient.delete('dashboard', createResult.id);
+
+      let error;
+      try {
+        error = await savedObjectsClient.get('dashboard', createResult.id);
+      } catch (e) {
+        error = e;
+      }
+      expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(true);
+    });
+  });
+
+  describe('addToWorkspaces', () => {
+    it('should throw forbidden error when workspace not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      let error;
+      try {
+        await savedObjectsClient.addToWorkspaces(
+          [{ type: 'dashboard', id: 'acl-controlled-dashboard-2' }],
+          ['workspace-1']
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should throw forbidden error when object ACL not permitted', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      const createResult = await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'dashboard',
+        {},
+        {
+          permissions: {
+            read: { users: ['foo'] },
+          },
+        }
+      );
+      let error;
+      try {
+        await savedObjectsClient.addToWorkspaces(
+          [{ type: 'dashboard', id: createResult.id }],
+          ['workspace-1']
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should be able to add to target workspaces', async () => {
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      const createResult = await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'dashboard',
+        {},
+        {
+          workspaces: ['workspace-2'],
+          permissions: {
+            read: { users: ['foo'] },
+            write: { users: ['foo'] },
+          },
+        }
+      );
+      await savedObjectsClient.addToWorkspaces(
+        [{ type: 'dashboard', id: createResult.id }],
+        ['workspace-1']
+      );
+
+      const result = await savedObjectsClient.find({
+        type: 'dashboard',
+        workspaces: ['workspace-1'],
+        perPage: 999,
+        page: 1,
+      });
+
+      expect(result.saved_objects.some((item) => item.id === createResult.id)).toBe(true);
+    });
+  });
+
+  describe('deleteByWorkspace', () => {
+    it('should throw forbidden error when workspace not permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+
+      let error;
+      try {
+        await savedObjectsClient.deleteByWorkspace('workspace-1');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should delete workspace 2 inner data when workspace permitted', async () => {
+      const savedObjectsClient = osd.coreStart.savedObjects.getScopedClient(
+        httpServerMock.createOpenSearchDashboardsRequest()
+      );
+      jest.spyOn(utilsExports, 'getPrincipalsFromRequest').mockReturnValue({
+        users: ['foo'],
+      });
+
+      await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'workspace',
+        {},
+        {
+          id: 'workspace-3',
+          permissions: {
+            library_read: { users: ['foo'] },
+            library_write: { users: ['foo'] },
+          },
+        }
+      );
+
+      await repositoryKit.create(
+        internalSavedObjectsRepository,
+        'dashboard',
+        {},
+        {
+          workspaces: ['workspace-3'],
+        }
+      );
+
+      await savedObjectsClient.deleteByWorkspace('workspace-3');
+
+      // Wait for delete be effected
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+
+      expect(
+        (
+          await savedObjectsClient.find({
+            type: 'dashboard',
+            workspaces: ['workspace-3'],
+            perPage: 999,
+            page: 1,
+          })
+        ).saved_objects.length
+      ).toEqual(0);
+    });
+  });
+});

--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -1,31 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
  */
 
 import { ISavedObjectsRepository, SavedObjectsClientContract } from 'src/core/server';

--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -67,6 +67,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           workspace: {
             enabled: true,
           },
+          migrations: { skip: false },
         },
       },
     });

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -431,7 +431,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       }
 
       // saved_objects
-      const permitted = await this.permissionControl.batchValidate(
+      const validateResult = await this.permissionControl.batchValidate(
         wrapperOptions.request,
         objects.map((savedObj) => ({
           ...savedObj,
@@ -439,7 +439,7 @@ export class WorkspaceSavedObjectsClientWrapper {
         [WorkspacePermissionMode.Write]
       );
 
-      if (!permitted) {
+      if (!validateResult.result) {
         throw generateSavedObjectsPermissionError();
       }
 
@@ -450,9 +450,13 @@ export class WorkspaceSavedObjectsClientWrapper {
       workspace: string,
       options: SavedObjectsDeleteByWorkspaceOptions = {}
     ) => {
-      await this.validateMultiWorkspacesPermissions([workspace], wrapperOptions.request, [
-        WorkspacePermissionMode.Write,
-      ]);
+      if (
+        !(await this.validateMultiWorkspacesPermissions([workspace], wrapperOptions.request, [
+          WorkspacePermissionMode.LibraryWrite,
+        ]))
+      ) {
+        throw generateWorkspacePermissionError();
+      }
 
       return await wrapperOptions.client.deleteByWorkspace(workspace, options);
     };


### PR DESCRIPTION
### Description

1. Fix permission validate for `addToWorkspaces` and `deleteByWorkspace` in client wrapper
2. Add integration tests for workspace saved object client wrapper

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
