### PR TITLE
Add workspace filter/column into saved objects page

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -356,4 +356,4 @@ export { __osdBootstrap__ } from './osd_bootstrap';
 
 export { WorkspacesStart, WorkspacesSetup, WorkspacesService } from './workspace';
 
-export { WORKSPACE_TYPE, cleanWorkspaceId } from '../utils';
+export { WORKSPACE_TYPE, cleanWorkspaceId, DEFAULT_WORKSPACE_ID } from '../utils';

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -354,7 +354,12 @@ export {
 } from './metrics';
 
 export { AppCategory, WorkspaceAttribute } from '../types';
-export { DEFAULT_APP_CATEGORIES, PUBLIC_WORKSPACE_ID, WORKSPACE_TYPE } from '../utils';
+export {
+  DEFAULT_APP_CATEGORIES,
+  PUBLIC_WORKSPACE_ID,
+  WORKSPACE_TYPE,
+  DEFAULT_WORKSPACE_ID,
+} from '../utils';
 
 export {
   SavedObject,

--- a/src/core/utils/constants.ts
+++ b/src/core/utils/constants.ts
@@ -9,4 +9,8 @@ export const WORKSPACE_PATH_PREFIX = '/w';
 
 export const PUBLIC_WORKSPACE_ID = 'public';
 
+/**
+ * deafult workspace is a virtual workspace,
+ * saved objects without any workspaces are consider belongs to default workspace
+ */
 export const DEFAULT_WORKSPACE_ID = 'default';

--- a/src/core/utils/constants.ts
+++ b/src/core/utils/constants.ts
@@ -8,3 +8,5 @@ export const WORKSPACE_TYPE = 'workspace';
 export const WORKSPACE_PATH_PREFIX = '/w';
 
 export const PUBLIC_WORKSPACE_ID = 'public';
+
+export const DEFAULT_WORKSPACE_ID = 'default';

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -38,4 +38,9 @@ export {
 } from './context';
 export { DEFAULT_APP_CATEGORIES } from './default_app_categories';
 export { getWorkspaceIdFromUrl, formatUrlWithWorkspaceId, cleanWorkspaceId } from './workspace';
-export { WORKSPACE_PATH_PREFIX, PUBLIC_WORKSPACE_ID, WORKSPACE_TYPE } from './constants';
+export {
+  WORKSPACE_PATH_PREFIX,
+  PUBLIC_WORKSPACE_ID,
+  WORKSPACE_TYPE,
+  DEFAULT_WORKSPACE_ID,
+} from './constants';

--- a/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
@@ -40,8 +40,8 @@ export interface SavedObjectCountOptions {
 export async function getSavedObjectCounts(
   http: HttpStart,
   options: SavedObjectCountOptions
-): Promise<Record<string, number>> {
-  return await http.post<Record<string, number>>(
+): Promise<Record<string, Record<string, number>>> {
+  return await http.post<Record<string, Record<string, number>>>(
     `/api/opensearch-dashboards/management/saved_objects/scroll/counts`,
     { body: JSON.stringify(options) }
   );

--- a/src/plugins/saved_objects_management/public/lib/parse_query.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/parse_query.test.ts
@@ -39,6 +39,8 @@ describe('getQueryText', () => {
           return [{ value: 'lala' }, { value: 'lolo' }];
         } else if (field === 'namespaces') {
           return [{ value: 'default' }];
+        } else if (field === 'workspaces') {
+          return [{ value: 'workspaces' }];
         }
         return [];
       },
@@ -47,6 +49,7 @@ describe('getQueryText', () => {
       queryText: 'foo bar',
       visibleTypes: 'lala',
       visibleNamespaces: 'default',
+      visibleWorkspaces: 'workspaces',
     });
   });
 });

--- a/src/plugins/saved_objects_management/public/lib/parse_query.ts
+++ b/src/plugins/saved_objects_management/public/lib/parse_query.ts
@@ -33,12 +33,15 @@ import { Query } from '@elastic/eui';
 interface ParsedQuery {
   queryText?: string;
   visibleTypes?: string[];
+  visibleNamespaces?: string[];
+  visibleWorkspaces?: string[];
 }
 
 export function parseQuery(query: Query): ParsedQuery {
   let queryText: string | undefined;
   let visibleTypes: string[] | undefined;
   let visibleNamespaces: string[] | undefined;
+  let visibleWorkspaces: string[] | undefined;
 
   if (query) {
     if (query.ast.getTermClauses().length) {
@@ -53,11 +56,15 @@ export function parseQuery(query: Query): ParsedQuery {
     if (query.ast.getFieldClauses('namespaces')) {
       visibleNamespaces = query.ast.getFieldClauses('namespaces')[0].value as string[];
     }
+    if (query.ast.getFieldClauses('workspaces')) {
+      visibleWorkspaces = query.ast.getFieldClauses('workspaces')[0].value as string[];
+    }
   }
 
   return {
     queryText,
     visibleTypes,
     visibleNamespaces,
+    visibleWorkspaces,
   };
 }

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
 >
   <Header
     filteredCount={4}
+    hideImport={false}
     onExportAll={[Function]}
     onImport={[Function]}
     onRefresh={[Function]}
@@ -260,6 +261,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           "has": [MockFunction],
         }
       }
+      availableWorkspaces={Array []}
       basePath={
         BasePath {
           "basePath": "",
@@ -279,6 +281,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           "has": [MockFunction],
         }
       }
+      currentWorkspaceId=""
       filters={
         Array [
           Object {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -203,7 +203,6 @@ exports[`SavedObjectsTable should render normally 1`] = `
 >
   <Header
     filteredCount={4}
-    hideImport={false}
     onExportAll={[Function]}
     onImport={[Function]}
     onRefresh={[Function]}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
@@ -40,29 +40,10 @@ describe('Header', () => {
       onRefresh: () => {},
       totalCount: 4,
       filteredCount: 2,
-      title: '',
     };
 
     const component = shallow(<Header {...props} />);
 
     expect(component).toMatchSnapshot();
-  });
-});
-
-describe('Header - workspace enabled', () => {
-  it('should hide `Import` button for application home state', () => {
-    const props = {
-      onExportAll: () => {},
-      onImport: () => {},
-      onRefresh: () => {},
-      totalCount: 4,
-      filteredCount: 2,
-      hideImport: true,
-      title: 'Saved Objectes',
-    };
-
-    const component = shallow(<Header {...props} />);
-
-    expect(component.find('EuiButtonEmpty[data-test-subj="importObjects"]').exists()).toBe(false);
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
@@ -40,10 +40,29 @@ describe('Header', () => {
       onRefresh: () => {},
       totalCount: 4,
       filteredCount: 2,
+      title: '',
     };
 
     const component = shallow(<Header {...props} />);
 
     expect(component).toMatchSnapshot();
+  });
+});
+
+describe('Header - workspace enabled', () => {
+  it('should hide `Import` button for application home state', () => {
+    const props = {
+      onExportAll: () => {},
+      onImport: () => {},
+      onRefresh: () => {},
+      totalCount: 4,
+      filteredCount: 2,
+      hideImport: true,
+      title: 'Saved Objectes',
+    };
+
+    const component = shallow(<Header {...props} />);
+
+    expect(component.find('EuiButtonEmpty[data-test-subj="importObjects"]').exists()).toBe(false);
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -45,11 +45,15 @@ export const Header = ({
   onImport,
   onRefresh,
   filteredCount,
+  hideImport,
+  title,
 }: {
   onExportAll: () => void;
   onImport: () => void;
   onRefresh: () => void;
   filteredCount: number;
+  hideImport?: boolean;
+  title: string;
 }) => (
   <Fragment>
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="baseline">
@@ -82,19 +86,21 @@ export const Header = ({
               />
             </EuiButtonEmpty>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              size="s"
-              iconType="importAction"
-              data-test-subj="importObjects"
-              onClick={onImport}
-            >
-              <FormattedMessage
-                id="savedObjectsManagement.objectsTable.header.importButtonLabel"
-                defaultMessage="Import"
-              />
-            </EuiButtonEmpty>
-          </EuiFlexItem>
+          {!hideImport && (
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="s"
+                iconType="importAction"
+                data-test-subj="importObjects"
+                onClick={onImport}
+              >
+                <FormattedMessage
+                  id="savedObjectsManagement.objectsTable.header.importButtonLabel"
+                  defaultMessage="Import"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          )}
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty size="s" iconType="refresh" onClick={onRefresh}>
               <FormattedMessage

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -45,15 +45,11 @@ export const Header = ({
   onImport,
   onRefresh,
   filteredCount,
-  hideImport,
-  title,
 }: {
   onExportAll: () => void;
   onImport: () => void;
   onRefresh: () => void;
   filteredCount: number;
-  hideImport?: boolean;
-  title: string;
 }) => (
   <Fragment>
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="baseline">
@@ -86,21 +82,19 @@ export const Header = ({
               />
             </EuiButtonEmpty>
           </EuiFlexItem>
-          {!hideImport && (
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size="s"
-                iconType="importAction"
-                data-test-subj="importObjects"
-                onClick={onImport}
-              >
-                <FormattedMessage
-                  id="savedObjectsManagement.objectsTable.header.importButtonLabel"
-                  defaultMessage="Import"
-                />
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          )}
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              iconType="importAction"
+              data-test-subj="importObjects"
+              onClick={onImport}
+            >
+              <FormattedMessage
+                id="savedObjectsManagement.objectsTable.header.importButtonLabel"
+                defaultMessage="Import"
+              />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty size="s" iconType="refresh" onClick={onRefresh}>
               <FormattedMessage

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
@@ -37,6 +37,7 @@ import { actionServiceMock } from '../../../services/action_service.mock';
 import { columnServiceMock } from '../../../services/column_service.mock';
 import { SavedObjectsManagementAction } from '../../..';
 import { Table, TableProps } from './table';
+import { WorkspaceAttribute } from 'opensearch-dashboards/public';
 
 const defaultProps: TableProps = {
   basePath: httpServiceMock.createSetupContract().basePath,
@@ -113,6 +114,50 @@ describe('Table', () => {
     const component = shallowWithI18nProvider(<Table {...defaultProps} />);
 
     expect(component).toMatchSnapshot();
+  });
+
+  it('should render gotoApp link correctly for workspace', () => {
+    const item = {
+      id: 'dashboard-1',
+      type: 'dashboard',
+      workspaces: ['ws-1'],
+      attributes: {},
+      references: [],
+      meta: {
+        title: `My-Dashboard-test`,
+        icon: 'indexPatternApp',
+        editUrl: '/management/opensearch-dashboards/objects/savedDashboards/dashboard-1',
+        inAppUrl: {
+          path: '/app/dashboards#/view/dashboard-1',
+          uiCapabilitiesPath: 'dashboard.show',
+        },
+      },
+    };
+    const props = {
+      ...defaultProps,
+      availableWorkspaces: [{ id: 'ws-1', name: 'My workspace' } as WorkspaceAttribute],
+      items: [item],
+    };
+    // not in a workspace
+    let component = shallowWithI18nProvider(<Table {...props} />);
+
+    let table = component.find('EuiBasicTable');
+    let columns = table.prop('columns') as any[];
+    let content = columns[1].render('My-Dashboard-test', item);
+    expect(content.props.href).toEqual('http://localhost/w/ws-1/app/dashboards#/view/dashboard-1');
+
+    // in a workspace
+    const currentWorkspaceId = 'foo-ws';
+    component = shallowWithI18nProvider(
+      <Table {...props} currentWorkspaceId={currentWorkspaceId} />
+    );
+
+    table = component.find('EuiBasicTable');
+    columns = table.prop('columns') as any[];
+    content = columns[1].render('My-Dashboard-test', item);
+    expect(content.props.href).toEqual(
+      `http://localhost/w/${currentWorkspaceId}/app/dashboards#/view/dashboard-1`
+    );
   });
 
   it('should handle query parse error', () => {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { IBasePath } from 'src/core/public';
+import { IBasePath, WorkspaceAttribute } from 'src/core/public';
 import React, { PureComponent, Fragment } from 'react';
 import moment from 'moment';
 import {
@@ -56,6 +56,7 @@ import {
   SavedObjectsManagementAction,
   SavedObjectsManagementColumnServiceStart,
 } from '../../../services';
+import { formatUrlWithWorkspaceId } from '../../../../../../core/public/utils';
 
 export interface TableProps {
   basePath: IBasePath;
@@ -83,6 +84,8 @@ export interface TableProps {
   onShowRelationships: (object: SavedObjectWithMetadata) => void;
   canGoInApp: (obj: SavedObjectWithMetadata) => boolean;
   dateFormat: string;
+  availableWorkspaces?: WorkspaceAttribute[];
+  currentWorkspaceId?: string;
 }
 
 interface TableState {
@@ -177,7 +180,11 @@ export class Table extends PureComponent<TableProps, TableState> {
       columnRegistry,
       namespaceRegistry,
       dateFormat,
+      availableWorkspaces,
+      currentWorkspaceId,
     } = this.props;
+
+    const visibleWsIds = availableWorkspaces?.map((ws) => ws.id) || [];
 
     const pagination = {
       pageIndex,
@@ -231,9 +238,19 @@ export class Table extends PureComponent<TableProps, TableState> {
           if (!canGoInApp) {
             return <EuiText size="s">{title || getDefaultTitle(object)}</EuiText>;
           }
-          return (
-            <EuiLink href={basePath.prepend(path)}>{title || getDefaultTitle(object)}</EuiLink>
-          );
+          let inAppUrl = basePath.prepend(path);
+          if (object.workspaces?.length) {
+            if (currentWorkspaceId) {
+              inAppUrl = formatUrlWithWorkspaceId(path, currentWorkspaceId, basePath);
+            } else {
+              // first workspace user have permission
+              const [workspaceId] = object.workspaces.filter((wsId) => visibleWsIds.includes(wsId));
+              if (workspaceId) {
+                inAppUrl = formatUrlWithWorkspaceId(path, workspaceId, basePath);
+              }
+            }
+          }
+          return <EuiLink href={inAppUrl}>{title || getDefaultTitle(object)}</EuiLink>;
         },
       } as EuiTableFieldDataColumnType<SavedObjectWithMetadata<any>>,
       {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -40,6 +40,7 @@ import {
 
 import React from 'react';
 import { Query } from '@elastic/eui';
+import { waitFor } from '@testing-library/dom';
 import { ShallowWrapper } from 'enzyme';
 import { shallowWithI18nProvider } from 'test_utils/enzyme_helpers';
 import {
@@ -65,7 +66,6 @@ import { SavedObjectWithMetadata } from '../../types';
 import { WorkspaceObject } from 'opensearch-dashboards/public';
 import { DEFAULT_WORKSPACE_ID } from '../../../../../core/public';
 import { TableProps } from './components/table';
-import { waitFor } from '@testing-library/dom';
 
 const allowedTypes = ['index-pattern', 'visualization', 'dashboard', 'search'];
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -66,7 +66,9 @@ import {
   OverlayStart,
   NotificationsStart,
   ApplicationStart,
+  WorkspaceAttribute,
 } from 'src/core/public';
+import { Subscription } from 'rxjs';
 import { RedirectAppLinks } from '../../../../opensearch_dashboards_react/public';
 import { IndexPatternsContract } from '../../../../data/public';
 import {
@@ -125,7 +127,7 @@ export interface SavedObjectsTableState {
   page: number;
   perPage: number;
   savedObjects: SavedObjectWithMetadata[];
-  savedObjectCounts: Record<string, number>;
+  savedObjectCounts: Record<string, Record<string, number>>;
   activeQuery: Query;
   selectedSavedObjects: SavedObjectWithMetadata[];
   isShowingImportFlyout: boolean;
@@ -139,25 +141,30 @@ export interface SavedObjectsTableState {
   exportAllOptions: ExportAllOption[];
   exportAllSelectedOptions: Record<string, boolean>;
   isIncludeReferencesDeepChecked: boolean;
-  currentWorkspaceId: string | null;
+  currentWorkspaceId?: string;
+  availableWorkspaces?: WorkspaceAttribute[];
   workspaceEnabled: boolean;
 }
 
 export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedObjectsTableState> {
   private _isMounted = false;
+  private currentWorkspaceIdSubscription?: Subscription;
+  private workspacesSubscription?: Subscription;
 
   constructor(props: SavedObjectsTableProps) {
     super(props);
+
+    const typeCounts = props.allowedTypes.reduce((typeToCountMap, type) => {
+      typeToCountMap[type] = 0;
+      return typeToCountMap;
+    }, {} as Record<string, number>);
 
     this.state = {
       totalCount: 0,
       page: 0,
       perPage: props.perPageConfig || 50,
       savedObjects: [],
-      savedObjectCounts: props.allowedTypes.reduce((typeToCountMap, type) => {
-        typeToCountMap[type] = 0;
-        return typeToCountMap;
-      }, {} as Record<string, number>),
+      savedObjectCounts: { type: typeCounts } as Record<string, Record<string, number>>,
       activeQuery: Query.parse(''),
       selectedSavedObjects: [],
       isShowingImportFlyout: false,
@@ -172,22 +179,32 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       exportAllSelectedOptions: {},
       isIncludeReferencesDeepChecked: true,
       currentWorkspaceId: this.props.workspaces.currentWorkspaceId$.getValue(),
+      availableWorkspaces: this.props.workspaces.workspaceList$.getValue(),
       workspaceEnabled: this.props.applications.capabilities.workspaces.enabled,
     };
   }
 
   private get workspaceIdQuery() {
-    const { currentWorkspaceId, workspaceEnabled } = this.state;
+    const { availableWorkspaces, currentWorkspaceId, workspaceEnabled } = this.state;
     // workspace is turned off
     if (!workspaceEnabled) {
       return undefined;
     } else {
+      // application home
       if (!currentWorkspaceId) {
-        return undefined;
+        return availableWorkspaces?.map((ws) => ws.id);
       } else {
         return [currentWorkspaceId];
       }
     }
+  }
+
+  private get wsNameIdLookup() {
+    const { availableWorkspaces } = this.state;
+    // Assumption: workspace name is unique across the system
+    return availableWorkspaces?.reduce((map, ws) => {
+      return map.set(ws.name, ws.id);
+    }, new Map<string, string>());
   }
 
   private formatWorkspaceIdParams<T extends { workspaces?: string[] }>(
@@ -202,6 +219,8 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
 
   componentDidMount() {
     this._isMounted = true;
+
+    this.subscribleWorkspace();
     this.fetchSavedObjects();
     this.fetchCounts();
   }
@@ -209,11 +228,15 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
   componentWillUnmount() {
     this._isMounted = false;
     this.debouncedFetchObjects.cancel();
+    this.currentWorkspaceIdSubscription?.unsubscribe();
+    this.workspacesSubscription?.unsubscribe();
   }
 
   fetchCounts = async () => {
     const { allowedTypes, namespaceRegistry } = this.props;
-    const { queryText, visibleTypes, visibleNamespaces } = parseQuery(this.state.activeQuery);
+    const { queryText, visibleTypes, visibleNamespaces, visibleWorkspaces } = parseQuery(
+      this.state.activeQuery
+    );
 
     const filteredTypes = filterQuery(allowedTypes, visibleTypes);
 
@@ -228,6 +251,11 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     if (availableNamespaces.length) {
       const filteredNamespaces = filterQuery(availableNamespaces, visibleNamespaces);
       filteredCountOptions.namespacesToInclude = filteredNamespaces;
+    }
+    if (visibleWorkspaces?.length) {
+      filteredCountOptions.workspaces = visibleWorkspaces
+        .map((wsName) => this.wsNameIdLookup?.get(wsName) || '')
+        .filter((wsId) => !!wsId);
     }
 
     // These are the saved objects visible in the table.
@@ -278,6 +306,19 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     this.setState({ isSearching: true }, this.debouncedFetchObjects);
   };
 
+  subscribleWorkspace = () => {
+    const workspace = this.props.workspaces;
+    this.currentWorkspaceIdSubscription = workspace.currentWorkspaceId$.subscribe((workspaceId) =>
+      this.setState({
+        currentWorkspaceId: workspaceId,
+      })
+    );
+
+    this.workspacesSubscription = workspace.workspaceList$.subscribe((workspaceList) => {
+      this.setState({ availableWorkspaces: workspaceList });
+    });
+  };
+
   fetchSavedObject = (type: string, id: string) => {
     this.setState({ isSearching: true }, () => this.debouncedFetchObject(type, id));
   };
@@ -285,7 +326,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
   debouncedFetchObjects = debounce(async () => {
     const { activeQuery: query, page, perPage } = this.state;
     const { notifications, http, allowedTypes, namespaceRegistry } = this.props;
-    const { queryText, visibleTypes, visibleNamespaces } = parseQuery(query);
+    const { queryText, visibleTypes, visibleNamespaces, visibleWorkspaces } = parseQuery(query);
     const filteredTypes = filterQuery(allowedTypes, visibleTypes);
     // "searchFields" is missing from the "findOptions" but gets injected via the API.
     // The API extracts the fields from each uiExports.savedObjectsManagement "defaultSearchField" attribute
@@ -302,6 +343,13 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     if (availableNamespaces.length) {
       const filteredNamespaces = filterQuery(availableNamespaces, visibleNamespaces);
       findOptions.namespaces = filteredNamespaces;
+    }
+
+    if (visibleWorkspaces?.length) {
+      const workspaceIds: string[] = visibleWorkspaces.map(
+        (wsName) => this.wsNameIdLookup?.get(wsName) || ''
+      );
+      findOptions.workspaces = workspaceIds;
     }
 
     if (findOptions.type.length > 1) {
@@ -846,6 +894,9 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       filteredItemCount,
       isSearching,
       savedObjectCounts,
+      availableWorkspaces,
+      workspaceEnabled,
+      currentWorkspaceId,
     } = this.state;
     const { http, allowedTypes, applications, namespaceRegistry } = this.props;
 
@@ -896,6 +947,35 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       });
     }
 
+    // Add workspace filter
+    if (workspaceEnabled && availableWorkspaces?.length) {
+      const wsCounts = savedObjectCounts.workspaces || {};
+      const wsFilterOptions = availableWorkspaces
+        .filter((ws) => {
+          return this.workspaceIdQuery?.includes(ws.id);
+        })
+        .map((ws) => {
+          return {
+            name: ws.name,
+            value: ws.name,
+            view: `${ws.name} (${wsCounts[ws.id] || 0})`,
+          };
+        });
+
+      filters.push({
+        type: 'field_value_selection',
+        field: 'workspaces',
+        name: i18n.translate('savedObjectsManagement.objectsTable.table.workspaceFilterName', {
+          defaultMessage: 'Workspaces',
+        }),
+        multiSelect: 'or',
+        options: wsFilterOptions,
+      });
+    }
+
+    // workspace enable and no workspace is selected
+    const hideImport = workspaceEnabled && !currentWorkspaceId;
+
     return (
       <EuiPageContent horizontalPosition="center">
         {this.renderFlyout()}
@@ -907,6 +987,8 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
           onImport={this.showImportFlyout}
           onRefresh={this.refreshObjects}
           filteredCount={filteredItemCount}
+          hideImport={hideImport}
+          title={this.props.title}
         />
         <EuiSpacer size="xs" />
         <RedirectAppLinks application={applications}>
@@ -933,6 +1015,8 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             onShowRelationships={this.onShowRelationships}
             canGoInApp={this.props.canGoInApp}
             dateFormat={this.props.dateFormat}
+            availableWorkspaces={availableWorkspaces}
+            currentWorkspaceId={currentWorkspaceId}
           />
         </RedirectAppLinks>
       </EuiPageContent>

--- a/src/plugins/saved_objects_management/server/routes/find.ts
+++ b/src/plugins/saved_objects_management/server/routes/find.ts
@@ -67,6 +67,7 @@ export const registerFindRoute = (
           workspaces: schema.maybe(
             schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
           ),
+          workspacesSearchOperator: schema.maybe(schema.string()),
         }),
       },
     },

--- a/src/plugins/saved_objects_management/server/routes/scroll_count.ts
+++ b/src/plugins/saved_objects_management/server/routes/scroll_count.ts
@@ -30,6 +30,7 @@
 
 import { schema } from '@osd/config-schema';
 import { IRouter, SavedObjectsFindOptions } from 'src/core/server';
+import { DEFAULT_WORKSPACE_ID } from '../../../../core/server';
 import { findAll } from '../lib';
 
 export const registerScrollForCountRoute = (router: IRouter) => {
@@ -69,6 +70,10 @@ export const registerScrollForCountRoute = (router: IRouter) => {
       if (requestHasWorkspaces) {
         counts.workspaces = {};
         findOptions.workspaces = req.body.workspaces;
+        if (findOptions.workspaces.indexOf(DEFAULT_WORKSPACE_ID) !== -1) {
+          // search both saved objects with workspace and without workspace
+          findOptions.workspacesSearchOperator = 'OR';
+        }
       }
 
       if (req.body.searchString) {
@@ -91,7 +96,7 @@ export const registerScrollForCountRoute = (router: IRouter) => {
           });
         }
         if (requestHasWorkspaces) {
-          const resultWorkspaces = result.workspaces || [];
+          const resultWorkspaces = result.workspaces || [DEFAULT_WORKSPACE_ID];
           resultWorkspaces.forEach((ws) => {
             counts.workspaces[ws] = counts.workspaces[ws] || 0;
             counts.workspaces[ws]++;

--- a/src/plugins/saved_objects_management/server/routes/scroll_count.ts
+++ b/src/plugins/saved_objects_management/server/routes/scroll_count.ts
@@ -47,7 +47,7 @@ export const registerScrollForCountRoute = (router: IRouter) => {
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const { client } = context.core.savedObjects;
-      const counts = {
+      const counts: Record<string, Record<string, number>> = {
         type: {},
       };
 
@@ -56,10 +56,10 @@ export const registerScrollForCountRoute = (router: IRouter) => {
         perPage: 1000,
       };
 
-      const requestHasWorkspaces = Array.isArray(req.body.workspaces) && req.body.workspaces.length;
-
       const requestHasNamespaces =
         Array.isArray(req.body.namespacesToInclude) && req.body.namespacesToInclude.length;
+
+      const requestHasWorkspaces = Array.isArray(req.body.workspaces) && req.body.workspaces.length;
 
       if (requestHasNamespaces) {
         counts.namespaces = {};
@@ -67,6 +67,7 @@ export const registerScrollForCountRoute = (router: IRouter) => {
       }
 
       if (requestHasWorkspaces) {
+        counts.workspaces = {};
         findOptions.workspaces = req.body.workspaces;
       }
 
@@ -89,6 +90,13 @@ export const registerScrollForCountRoute = (router: IRouter) => {
             counts.namespaces[ns]++;
           });
         }
+        if (requestHasWorkspaces) {
+          const resultWorkspaces = result.workspaces || [];
+          resultWorkspaces.forEach((ws) => {
+            counts.workspaces[ws] = counts.workspaces[ws] || 0;
+            counts.workspaces[ws]++;
+          });
+        }
         counts.type[type] = counts.type[type] || 0;
         counts.type[type]++;
       });
@@ -103,6 +111,13 @@ export const registerScrollForCountRoute = (router: IRouter) => {
       for (const ns of namespacesToInclude) {
         if (!counts.namespaces[ns]) {
           counts.namespaces[ns] = 0;
+        }
+      }
+
+      const workspacesToInclude = req.body.workspaces || [];
+      for (const ws of workspacesToInclude) {
+        if (!counts.workspaces[ws]) {
+          counts.workspaces[ws] = 0;
         }
       }
 

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -6,6 +6,6 @@
   "requiredPlugins": [
     "savedObjects"
   ],
-  "optionalPlugins": [],
+  "optionalPlugins": ["savedObjectsManagement"],
   "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/public/components/workspace_column/index.ts
+++ b/src/plugins/workspace/public/components/workspace_column/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { getWorkspaceColumn, WorkspaceColumn } from './workspace_column';

--- a/src/plugins/workspace/public/components/workspace_column/workspace_colum.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_column/workspace_colum.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import { coreMock } from '../../../../../core/public/mocks';
+import { render } from '@testing-library/react';
+import { WorkspaceColumn } from './workspace_column';
+
+describe('workspace column in saved objects page', () => {
+  const coreSetup = coreMock.createSetup();
+  const workspaceList = [
+    {
+      id: 'ws-1',
+      name: 'foo',
+    },
+    {
+      id: 'ws-2',
+      name: 'bar',
+    },
+  ];
+  coreSetup.workspaces.workspaceList$.next(workspaceList);
+
+  it('should show workspace name correctly', () => {
+    const workspaces = ['ws-1', 'ws-2'];
+    const { container } = render(<WorkspaceColumn coreSetup={coreSetup} workspaces={workspaces} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="euiText euiText--medium"
+        >
+          foo | bar
+        </div>
+      </div>
+    `);
+  });
+
+  it('show empty when no workspace', () => {
+    const { container } = render(<WorkspaceColumn coreSetup={coreSetup} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="euiText euiText--medium"
+        />
+      </div>
+    `);
+  });
+
+  it('show empty when workspace can not found', () => {
+    const { container } = render(<WorkspaceColumn coreSetup={coreSetup} workspaces={['ws-404']} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="euiText euiText--medium"
+        />
+      </div>
+    `);
+  });
+});

--- a/src/plugins/workspace/public/components/workspace_column/workspace_column.tsx
+++ b/src/plugins/workspace/public/components/workspace_column/workspace_column.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import useObservable from 'react-use/lib/useObservable';
+import { i18n } from '@osd/i18n';
+import { WorkspaceAttribute, CoreSetup } from '../../../../../core/public';
+import { SavedObjectsManagementColumn } from '../../../../saved_objects_management/public';
+
+interface WorkspaceColumnProps {
+  coreSetup: CoreSetup;
+  workspaces?: string[];
+}
+
+export function WorkspaceColumn({ coreSetup, workspaces }: WorkspaceColumnProps) {
+  const workspaceList = useObservable(coreSetup.workspaces.workspaceList$);
+
+  const wsLookUp = workspaceList?.reduce((map, ws) => {
+    return map.set(ws.id, ws.name);
+  }, new Map<string, string>());
+
+  const workspaceNames = workspaces?.map((wsId) => wsLookUp?.get(wsId)).join(' | ');
+
+  return <EuiText>{workspaceNames}</EuiText>;
+}
+
+export function getWorkspaceColumn(
+  coreSetup: CoreSetup
+): SavedObjectsManagementColumn<WorkspaceAttribute | undefined> {
+  return {
+    id: 'workspace_column',
+    euiColumn: {
+      align: 'left',
+      field: 'workspaces',
+      name: i18n.translate('savedObjectsManagement.objectsTable.table.columnWorkspacesName', {
+        defaultMessage: 'Workspaces',
+      }),
+      render: (workspaces: string[]) => {
+        return <WorkspaceColumn coreSetup={coreSetup} workspaces={workspaces} />;
+      },
+    },
+    loadData: () => {
+      return Promise.resolve(undefined);
+    },
+  };
+}

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -9,7 +9,7 @@ import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../co
 import { WorkspacePlugin } from './plugin';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { Observable, Subscriber } from 'rxjs';
-import { savedObjectsManagementPluginMock } from 'src/plugins/saved_objects_management/public/mocks';
+import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
 
 describe('Workspace plugin', () => {
   beforeEach(() => {

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -133,7 +133,9 @@ describe('Workspace plugin', () => {
   it('#setup register workspace dropdown menu when setup', async () => {
     const setupMock = coreMock.createSetup();
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock);
+    await workspacePlugin.setup(setupMock, {
+      savedObjectsManagement: savedObjectsManagementPluginMock.createSetupContract(),
+    });
     expect(setupMock.chrome.registerCollapsibleNavHeader).toBeCalledTimes(1);
   });
 });

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -9,6 +9,7 @@ import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../co
 import { WorkspacePlugin } from './plugin';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { Observable, Subscriber } from 'rxjs';
+import { savedObjectsManagementPluginMock } from 'src/plugins/saved_objects_management/public/mocks';
 
 describe('Workspace plugin', () => {
   beforeEach(() => {
@@ -17,11 +18,15 @@ describe('Workspace plugin', () => {
   });
   it('#setup', async () => {
     const setupMock = coreMock.createSetup();
+    const savedObjectManagementSetupMock = savedObjectsManagementPluginMock.createSetupContract();
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock);
+    await workspacePlugin.setup(setupMock, {
+      savedObjectsManagement: savedObjectManagementSetupMock,
+    });
     expect(setupMock.application.register).toBeCalledTimes(1);
     expect(WorkspaceClientMock).toBeCalledTimes(1);
     expect(workspaceClientMock.enterWorkspace).toBeCalledTimes(0);
+    expect(savedObjectManagementSetupMock.columns.register).toBeCalledTimes(1);
   });
 
   it('#setup when workspace id is in url and enterWorkspace return error', async () => {
@@ -53,7 +58,9 @@ describe('Workspace plugin', () => {
     });
 
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock);
+    await workspacePlugin.setup(setupMock, {
+      savedObjectsManagement: savedObjectsManagementPluginMock.createSetupContract(),
+    });
     expect(setupMock.application.register).toBeCalledTimes(1);
     expect(WorkspaceClientMock).toBeCalledTimes(1);
     expect(workspaceClientMock.enterWorkspace).toBeCalledWith('workspaceId');
@@ -107,7 +114,9 @@ describe('Workspace plugin', () => {
     });
 
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock);
+    await workspacePlugin.setup(setupMock, {
+      savedObjectsManagement: savedObjectsManagementPluginMock.createSetupContract(),
+    });
     currentAppIdSubscriber?.next(WORKSPACE_FATAL_ERROR_APP_ID);
     expect(applicationStartMock.navigateToApp).toBeCalledWith(WORKSPACE_OVERVIEW_APP_ID);
     windowSpy.mockRestore();

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Subscription } from 'rxjs';
+import { SavedObjectsManagementPluginSetup } from 'src/plugins/saved_objects_management/public';
 import { featureMatchesConfig } from './utils';
 import {
   AppMountParameters,
@@ -19,9 +20,14 @@ import { getWorkspaceIdFromUrl } from '../../../core/public/utils';
 import { renderWorkspaceMenu } from './render_workspace_menu';
 import { Services } from './types';
 import { WorkspaceClient } from './workspace_client';
+import { getWorkspaceColumn } from './components/workspace_column';
 import { NavLinkWrapper } from '../../../core/public/chrome/nav_links/nav_link';
 
 type WorkspaceAppType = (params: AppMountParameters, services: Services) => () => void;
+
+interface WorkspacePluginSetupDeps {
+  savedObjectsManagement?: SavedObjectsManagementPluginSetup;
+}
 
 export class WorkspacePlugin implements Plugin<{}, {}> {
   private coreStart?: CoreStart;
@@ -88,7 +94,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
     }
   }
 
-  public async setup(core: CoreSetup) {
+  public async setup(core: CoreSetup, { savedObjectsManagement }: WorkspacePluginSetupDeps) {
     const workspaceClient = new WorkspaceClient(core.http, core.workspaces);
     await workspaceClient.init();
     /**
@@ -160,6 +166,11 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
       }
       return renderWorkspaceMenu(this.coreStart);
     });
+
+    /**
+     * register workspace column into saved objects table
+     */
+    savedObjectsManagement?.columns.register(getWorkspaceColumn(core));
 
     return {};
   }


### PR DESCRIPTION
### Description
1. Add workspace filter into saved objects page
2. Add workspace column into saved objects page

**workspace column**
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/113890546/8d95bb81-8045-49d9-9e43-667037974ad0)

**workspace filter includes default workspace**
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/113890546/b4a4a10f-d832-4ea1-9dbc-083b87e5c7b4)


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
