### PR TITLE
fix: create and bulkCreate override with target workspaces

### DIFF
--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -285,6 +285,20 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
 
       expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
     });
+
+    it('should able to create with override', async () => {
+      const createResult = await permittedSavedObjectedClient.create(
+        'dashboard',
+        {},
+        {
+          id: 'inner-workspace-dashboard-1',
+          overwrite: true,
+          workspaces: ['workspace-1'],
+        }
+      );
+
+      expect(createResult.error).toBeUndefined();
+    });
   });
 
   describe('bulkCreate', () => {
@@ -311,6 +325,47 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
       );
       expect(result.saved_objects.length).toEqual(1);
       await permittedSavedObjectedClient.delete('dashboard', objectId);
+    });
+
+    it('should throw forbidden error when create with override', async () => {
+      let error;
+      try {
+        await notPermittedSavedObjectedClient.bulkCreate(
+          [
+            {
+              id: 'inner-workspace-dashboard-1',
+              type: 'dashboard',
+              attributes: {},
+            },
+          ],
+          {
+            overwrite: true,
+            workspaces: ['workspace-1'],
+          }
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should able to bulk create with override', async () => {
+      const createResult = await permittedSavedObjectedClient.bulkCreate(
+        [
+          {
+            id: 'inner-workspace-dashboard-1',
+            type: 'dashboard',
+            attributes: {},
+          },
+        ],
+        {
+          overwrite: true,
+          workspaces: ['workspace-1'],
+        }
+      );
+
+      expect(createResult.saved_objects).toHaveLength(1);
     });
   });
 

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -257,7 +257,14 @@ export class WorkspaceSavedObjectsClientWrapper {
         throw generateSavedObjectsPermissionError();
       }
 
-      if (options.overwrite) {
+      /**
+       *
+       * If target workspaces parameter exists, we don't need to do permission validation again.
+       * The bulk create method in repository doesn't allow extends workspaces with override.
+       * If target workspaces parameter doesn't exists, we need to check if has permission to object's workspaces or ACL.
+       *
+       */
+      if (!hasTargetWorkspaces && options.overwrite) {
         for (const object of objects) {
           const { type, id } = object;
           if (id) {
@@ -276,10 +283,7 @@ export class WorkspaceSavedObjectsClientWrapper {
               !(await this.validateWorkspacesAndSavedObjectsPermissions(
                 rawObject,
                 wrapperOptions.request,
-                !hasTargetWorkspaces
-                  ? // If no workspaces are passed, we need to check the workspace permission of object when overwrite.
-                    [WorkspacePermissionMode.LibraryWrite]
-                  : [],
+                [WorkspacePermissionMode.LibraryWrite],
                 [WorkspacePermissionMode.Write],
                 false
               ))
@@ -303,7 +307,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       if (
         hasTargetWorkspaces &&
         !(await this.validateMultiWorkspacesPermissions(
-          options.workspaces ?? [],
+          options?.workspaces ?? [],
           wrapperOptions.request,
           [WorkspacePermissionMode.LibraryWrite]
         ))
@@ -311,16 +315,21 @@ export class WorkspaceSavedObjectsClientWrapper {
         throw generateWorkspacePermissionError();
       }
 
+      /**
+       *
+       * If target workspaces parameter exists, we don't need to do permission validation again.
+       * The create method in repository doesn't allow extends workspaces with override.
+       * If target workspaces parameter doesn't exists, we need to check if has permission to object's workspaces or ACL.
+       *
+       */
       if (
         options?.overwrite &&
         options.id &&
+        !hasTargetWorkspaces &&
         !(await this.validateWorkspacesAndSavedObjectsPermissions(
           await wrapperOptions.client.get(type, options.id),
           wrapperOptions.request,
-          !hasTargetWorkspaces
-            ? // If no workspaces are passed, we need to check the workspace permission of object when overwrite.
-              [WorkspacePermissionMode.LibraryWrite]
-            : [],
+          [WorkspacePermissionMode.LibraryWrite],
           [WorkspacePermissionMode.Write],
           false
         ))


### PR DESCRIPTION
### Description

Fix create and bulkCreate can't override with permitted target workspaces 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
