### PR TITLE
navigate to create workspace/workspaces list page without refreshing

### DIFF
--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -102,6 +102,7 @@ interface StartDeps {
 type CollapsibleNavHeaderRender = (context: {
   basePath: HttpStart['basePath'];
   getUrlForApp: InternalApplicationStart['getUrlForApp'];
+  navigateToUrl: InternalApplicationStart['navigateToUrl'];
   workspaces: WorkspacesStart;
 }) => JSX.Element | null;
 
@@ -202,6 +203,7 @@ export class ChromeService {
             basePath: http.basePath,
             workspaces,
             getUrlForApp: application.getUrlForApp,
+            navigateToUrl: application.navigateToUrl,
           })
         : null;
 

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -15,6 +15,7 @@ import {
   EuiPopover,
   EuiText,
 } from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
 
 import {
   ApplicationStart,
@@ -32,6 +33,7 @@ import { formatUrlWithWorkspaceId } from '../../utils';
 
 interface Props {
   getUrlForApp: ApplicationStart['getUrlForApp'];
+  navigateToUrl: ApplicationStart['navigateToUrl'];
   basePath: HttpSetup['basePath'];
   workspaces: WorkspacesStart;
 }
@@ -50,7 +52,7 @@ function getFilteredWorkspaceList(
   ].slice(0, 5);
 }
 
-export const WorkspaceMenu = ({ basePath, getUrlForApp, workspaces }: Props) => {
+export const WorkspaceMenu = ({ basePath, getUrlForApp, workspaces, navigateToUrl }: Props) => {
   const [isPopoverOpen, setPopover] = useState(false);
   const currentWorkspace = useObservable(workspaces.currentWorkspace$, null);
   const workspaceList = useObservable(workspaces.workspaceList$, []);
@@ -103,8 +105,8 @@ export const WorkspaceMenu = ({ basePath, getUrlForApp, workspaces }: Props) => 
   };
 
   const getWorkspaceListItems = () => {
-    const workspaceListItems = filteredWorkspaceList.map((workspace, index) =>
-      workspaceToItem(workspace, index)
+    const workspaceListItems: EuiContextMenuPanelItemDescriptor[] = filteredWorkspaceList.map(
+      (workspace, index) => workspaceToItem(workspace, index)
     );
     const length = workspaceListItems.length;
     workspaceListItems.push({
@@ -113,13 +115,18 @@ export const WorkspaceMenu = ({ basePath, getUrlForApp, workspaces }: Props) => 
         defaultMessage: 'Create workspace',
       }),
       key: length.toString(),
-      href: formatUrlWithWorkspaceId(
-        getUrlForApp(WORKSPACE_CREATE_APP_ID, {
-          absolute: false,
-        }),
-        currentWorkspace?.id ?? '',
-        basePath
-      ),
+      onClick: () => {
+        navigateToUrl(
+          formatUrlWithWorkspaceId(
+            getUrlForApp(WORKSPACE_CREATE_APP_ID, {
+              absolute: false,
+            }),
+            currentWorkspace?.id ?? '',
+            basePath
+          )
+        );
+        setPopover(false);
+      },
     });
     workspaceListItems.push({
       icon: <EuiIcon type="folderClosed" />,
@@ -127,13 +134,18 @@ export const WorkspaceMenu = ({ basePath, getUrlForApp, workspaces }: Props) => 
         defaultMessage: 'All workspaces',
       }),
       key: (length + 1).toString(),
-      href: formatUrlWithWorkspaceId(
-        getUrlForApp(WORKSPACE_LIST_APP_ID, {
-          absolute: false,
-        }),
-        currentWorkspace?.id ?? '',
-        basePath
-      ),
+      onClick: () => {
+        navigateToUrl(
+          formatUrlWithWorkspaceId(
+            getUrlForApp(WORKSPACE_LIST_APP_ID, {
+              absolute: false,
+            }),
+            currentWorkspace?.id ?? '',
+            basePath
+          )
+        );
+        setPopover(false);
+      },
     });
     return workspaceListItems;
   };

--- a/src/plugins/workspace/public/render_workspace_menu.tsx
+++ b/src/plugins/workspace/public/render_workspace_menu.tsx
@@ -11,10 +11,19 @@ export function renderWorkspaceMenu({
   basePath,
   getUrlForApp,
   workspaces,
+  navigateToUrl,
 }: {
   getUrlForApp: ApplicationStart['getUrlForApp'];
   basePath: HttpSetup['basePath'];
   workspaces: WorkspacesStart;
+  navigateToUrl: ApplicationStart['navigateToUrl'];
 }) {
-  return <WorkspaceMenu basePath={basePath} getUrlForApp={getUrlForApp} workspaces={workspaces} />;
+  return (
+    <WorkspaceMenu
+      basePath={basePath}
+      getUrlForApp={getUrlForApp}
+      workspaces={workspaces}
+      navigateToUrl={navigateToUrl}
+    />
+  );
 }


### PR DESCRIPTION
### Description

currently, navigate to "Create workspace" page and "All workspace" list page from workspace context menu triggers a full page reload which is unnecessary.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
