### PR TITLE
Support disable permission check on workspace

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -276,5 +276,6 @@
 
 # Set the value to true enable workspace feature
 # workspace.enabled: false
-# Set the value to true to enable permission check on workspace, to enable this Opensearch Dashboard must have authentication enabled
-# workspace.permission.enabled: false
+# Set the value to false to disable permission check on workspace
+# Permission check depends on OpenSearch Dashboards has authentication enabled, set it to false if no authentication is configured
+# workspace.permission.enabled: true

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -273,3 +273,8 @@
 
 # Set the value of this setting to true to enable plugin augmentation on Dashboard
 # vis_augmenter.pluginAugmentationEnabled: true
+
+# Set the value to true enable workspace feature
+# workspace.enabled: false
+# Set the value to true to enable permission check on workspace, to enable this Opensearch Dashboard must have authentication enabled
+# workspace.permission.enabled: false

--- a/src/plugins/workspace/config.ts
+++ b/src/plugins/workspace/config.ts
@@ -7,6 +7,9 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
+  permission: schema.object({
+    enabled: schema.boolean({ defaultValue: true }),
+  }),
 });
 
-export type ConfigSchema = TypeOf<typeof configSchema>;
+export type WorkspacePluginConfigType = TypeOf<typeof configSchema>;

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -17,7 +17,7 @@ export const WorkspaceCreator = () => {
     services: { application, notifications, http, workspaceClient },
   } = useOpenSearchDashboards<{ workspaceClient: WorkspaceClient }>();
 
-  const isPermissionEnabld = application?.capabilities.workspaces.permissionEnabled;
+  const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
   const handleWorkspaceFormSubmit = useCallback(
     async (data: WorkspaceFormSubmitData) => {
       let result;
@@ -77,7 +77,7 @@ export const WorkspaceCreator = () => {
               onSubmit={handleWorkspaceFormSubmit}
               opType={WORKSPACE_OP_TYPE_CREATE}
               permissionFirstRowDeletable
-              permissionEnabld={isPermissionEnabld}
+              permissionEnabled={isPermissionEnabled}
             />
           )}
         </EuiPageContent>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -17,6 +17,7 @@ export const WorkspaceCreator = () => {
     services: { application, notifications, http, workspaceClient },
   } = useOpenSearchDashboards<{ workspaceClient: WorkspaceClient }>();
 
+  const isPermissionEnabld = application?.capabilities.workspaces.permissionEnabled;
   const handleWorkspaceFormSubmit = useCallback(
     async (data: WorkspaceFormSubmitData) => {
       let result;
@@ -76,6 +77,7 @@ export const WorkspaceCreator = () => {
               onSubmit={handleWorkspaceFormSubmit}
               opType={WORKSPACE_OP_TYPE_CREATE}
               permissionFirstRowDeletable
+              permissionEnabld={isPermissionEnabld}
             />
           )}
         </EuiPageContent>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
@@ -113,7 +113,7 @@ interface WorkspaceFormProps {
   defaultValues?: WorkspaceFormData;
   opType?: string;
   permissionFirstRowDeletable?: boolean;
-  permissionEnabld?: boolean;
+  permissionEnabled?: boolean;
 }
 
 export const WorkspaceForm = ({
@@ -122,7 +122,7 @@ export const WorkspaceForm = ({
   defaultValues,
   opType,
   permissionFirstRowDeletable,
-  permissionEnabld,
+  permissionEnabled,
 }: WorkspaceFormProps) => {
   const applications = useApplications(application);
   const workspaceNameReadOnly = defaultValues?.reserved;
@@ -502,7 +502,7 @@ export const WorkspaceForm = ({
         </EuiPanel>
       )}
       <EuiSpacer />
-      {permissionEnabld && (
+      {permissionEnabled && (
         <EuiPanel>
           <EuiTitle size="s">
             <h2>Members & permissions</h2>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
@@ -113,6 +113,7 @@ interface WorkspaceFormProps {
   defaultValues?: WorkspaceFormData;
   opType?: string;
   permissionFirstRowDeletable?: boolean;
+  permissionEnabld?: boolean;
 }
 
 export const WorkspaceForm = ({
@@ -121,6 +122,7 @@ export const WorkspaceForm = ({
   defaultValues,
   opType,
   permissionFirstRowDeletable,
+  permissionEnabld,
 }: WorkspaceFormProps) => {
   const applications = useApplications(application);
   const workspaceNameReadOnly = defaultValues?.reserved;
@@ -500,17 +502,19 @@ export const WorkspaceForm = ({
         </EuiPanel>
       )}
       <EuiSpacer />
-      <EuiPanel>
-        <EuiTitle size="s">
-          <h2>Members & permissions</h2>
-        </EuiTitle>
-        <WorkspacePermissionSettingPanel
-          errors={formErrors.permissions}
-          value={permissionSettings}
-          onChange={setPermissionSettings}
-          firstRowDeletable={permissionFirstRowDeletable}
-        />
-      </EuiPanel>
+      {permissionEnabld && (
+        <EuiPanel>
+          <EuiTitle size="s">
+            <h2>Members & permissions</h2>
+          </EuiTitle>
+          <WorkspacePermissionSettingPanel
+            errors={formErrors.permissions}
+            value={permissionSettings}
+            onChange={setPermissionSettings}
+            firstRowDeletable={permissionFirstRowDeletable}
+          />
+        </EuiPanel>
+      )}
       <EuiSpacer />
       <EuiText textAlign="right">
         {opType === WORKSPACE_OP_TYPE_CREATE && (

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -46,7 +46,7 @@ export const WorkspaceUpdater = () => {
     services: { application, workspaces, notifications, http, workspaceClient },
   } = useOpenSearchDashboards<{ workspaceClient: WorkspaceClient }>();
 
-  const isPermissionEnabld = application?.capabilities.workspaces.permissionEnabled;
+  const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
 
   const currentWorkspace = useObservable(workspaces ? workspaces.currentWorkspace$ : of(null));
   const hideDeleteButton = !!currentWorkspace?.reserved; // hide delete button for reserved workspace
@@ -193,7 +193,7 @@ export const WorkspaceUpdater = () => {
               onSubmit={handleWorkspaceFormSubmit}
               defaultValues={currentWorkspaceFormData}
               opType={WORKSPACE_OP_TYPE_UPDATE}
-              permissionEnabld={isPermissionEnabld}
+              permissionEnabled={isPermissionEnabled}
             />
           )}
         </EuiPageContent>

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -46,6 +46,8 @@ export const WorkspaceUpdater = () => {
     services: { application, workspaces, notifications, http, workspaceClient },
   } = useOpenSearchDashboards<{ workspaceClient: WorkspaceClient }>();
 
+  const isPermissionEnabld = application?.capabilities.workspaces.permissionEnabled;
+
   const currentWorkspace = useObservable(workspaces ? workspaces.currentWorkspace$ : of(null));
   const hideDeleteButton = !!currentWorkspace?.reserved; // hide delete button for reserved workspace
   const [deleteWorkspaceModalVisible, setDeleteWorkspaceModalVisible] = useState(false);
@@ -191,6 +193,7 @@ export const WorkspaceUpdater = () => {
               onSubmit={handleWorkspaceFormSubmit}
               defaultValues={currentWorkspaceFormData}
               opType={WORKSPACE_OP_TYPE_UPDATE}
+              permissionEnabld={isPermissionEnabld}
             />
           )}
         </EuiPageContent>

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -27,6 +27,9 @@ describe('workspace service', () => {
         osd: {
           workspace: {
             enabled: true,
+            permission: {
+              enabled: false,
+            },
           },
         },
       },


### PR DESCRIPTION
### Description

When OSD don't have authentication enabled, there is no user/role. In this case, permission check for workspace need to be disabled, otherwise it will block the access to saved objects belongs to workspaces.

To support this we could check whether authentication has configured, but it lose the flexibility to turn on/off based on user's need.

By adding a new flag in yml file, it is more flexible, user could turn permission check off even if authentication is enabled.

**This flag will skip permission check totally. However, for creating/updating workspace, it will still persistent the ACL related information, that info could be reuse when permission check turned on.**

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
