### PR TITLE
[Backport workspace]Add unit test for delete saved objects by workspace

### DIFF
--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -804,7 +804,7 @@ export class SavedObjectsRepository {
   }
 
   /**
-   * Deletes all objects from the provided workspace. It used when delete a workspace.
+   * Deletes all objects from the provided workspace. It used when deleting a workspace.
    *
    * @param {string} workspace
    * @param options SavedObjectsDeleteByWorkspaceOptions

--- a/src/core/server/saved_objects/service/saved_objects_client.test.js
+++ b/src/core/server/saved_objects/service/saved_objects_client.test.js
@@ -207,3 +207,18 @@ test(`#deleteFromNamespaces`, async () => {
   expect(mockRepository.deleteFromNamespaces).toHaveBeenCalledWith(type, id, namespaces, options);
   expect(result).toBe(returnValue);
 });
+
+test(`#deleteByWorkspace`, async () => {
+  const returnValue = Symbol();
+  const mockRepository = {
+    deleteByWorkspace: jest.fn().mockResolvedValue(returnValue),
+  };
+  const client = new SavedObjectsClient(mockRepository);
+
+  const workspace = Symbol();
+  const options = Symbol();
+  const result = await client.deleteByWorkspace(workspace, options);
+
+  expect(mockRepository.deleteByWorkspace).toHaveBeenCalledWith(workspace, options);
+  expect(result).toBe(returnValue);
+});

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -54,7 +54,8 @@ describe('workspace service', () => {
         .expect(200);
       await Promise.all(
         listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
-          // this will delete reserved workspace
+          // workspace delete API will not able to delete reserved workspace
+          // to clean up the test data, change it saved objects delete API
           osdTestServer.request
             .delete(root, `/api/saved_objects/${WORKSPACE_TYPE}/${item.id}`)
             .expect(200)

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -8,6 +8,7 @@ import { omit } from 'lodash';
 import * as osdTestServer from '../../../../core/test_helpers/osd_server';
 import { WorkspaceRoutePermissionItem } from '../types';
 import { WorkspacePermissionMode } from '../../../../core/server';
+import { WORKSPACE_TYPE } from '../../../../core/server';
 
 const testWorkspace: WorkspaceAttribute & {
   permissions: WorkspaceRoutePermissionItem;
@@ -31,6 +32,7 @@ describe('workspace service', () => {
               enabled: false,
             },
           },
+          migrations: { skip: false },
         },
       },
     });
@@ -52,7 +54,10 @@ describe('workspace service', () => {
         .expect(200);
       await Promise.all(
         listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
-          osdTestServer.request.delete(root, `/api/workspaces/${item.id}`).expect(200)
+          // this will delete reserved workspace
+          osdTestServer.request
+            .delete(root, `/api/saved_objects/${WORKSPACE_TYPE}/${item.id}`)
+            .expect(200)
         )
       );
     });
@@ -123,6 +128,16 @@ describe('workspace service', () => {
         .expect(200);
 
       await osdTestServer.request
+        .post(root, `/api/saved_objects/index-pattern/logstash-*`)
+        .send({
+          attributes: {
+            title: 'logstash-*',
+          },
+          workspaces: [result.body.result.id],
+        })
+        .expect(200);
+
+      await osdTestServer.request
         .delete(root, `/api/workspaces/${result.body.result.id}`)
         .expect(200);
 
@@ -132,6 +147,29 @@ describe('workspace service', () => {
       );
 
       expect(getResult.body.success).toEqual(false);
+
+      // saved objects been deleted
+      await osdTestServer.request
+        .get(root, `/api/saved_objects/index-pattern/logstash-*`)
+        .expect(404);
+    });
+    it('delete reserved workspace', async () => {
+      const reservedWorkspace: WorkspaceAttribute = { ...testWorkspace, reserved: true };
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(reservedWorkspace, 'id'),
+        })
+        .expect(200);
+
+      const deleteResult = await osdTestServer.request
+        .delete(root, `/api/workspaces/${result.body.result.id}`)
+        .expect(200);
+
+      expect(deleteResult.body.success).toEqual(false);
+      expect(deleteResult.body.error).toEqual(
+        `Reserved workspace ${result.body.result.id} is not allowed to delete.`
+      );
     });
     it('list', async () => {
       await osdTestServer.request
@@ -147,7 +185,7 @@ describe('workspace service', () => {
           page: 1,
         })
         .expect(200);
-      expect(listResult.body.result.total).toEqual(3);
+      expect(listResult.body.result.total).toEqual(1);
     });
   });
 });

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -387,13 +387,14 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
         return {
           success: false,
           error: i18n.translate('workspace.deleteReservedWorkspace.errorMessage', {
-            defaultMessage: 'Reserved workspace {id} is not allowed to delete: ',
+            defaultMessage: 'Reserved workspace {id} is not allowed to delete.',
             values: { id: workspaceInDB.id },
           }),
         };
       }
-      await savedObjectClient.delete(WORKSPACE_TYPE, id);
       await savedObjectClient.deleteByWorkspace(id);
+      // delete workspace itself at last, deleteByWorkspace depends on the workspace to do permission check
+      await savedObjectClient.delete(WORKSPACE_TYPE, id);
       return {
         success: true,
         result: true,


### PR DESCRIPTION
### Description

Backport delete saved objects by workspace unit test cases into workspace branch

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
