### PR TITLE
feature: cannot delete last admin user/group in workspace settings

### DIFF
--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -78,7 +78,7 @@ export const WorkspaceCreator = () => {
               onSubmit={handleWorkspaceFormSubmit}
               opType={WORKSPACE_OP_TYPE_CREATE}
               permissionEnabled={isPermissionEnabled}
-              permissionFirstUserDeletable
+              permissionLastAdminItemDeletable
             />
           )}
         </EuiPageContent>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_form.tsx
@@ -140,7 +140,7 @@ interface WorkspaceFormProps {
   defaultValues?: WorkspaceFormData;
   opType?: string;
   permissionEnabled?: boolean;
-  permissionFirstUserDeletable?: boolean;
+  permissionLastAdminItemDeletable?: boolean;
 }
 
 export const WorkspaceForm = ({
@@ -149,7 +149,7 @@ export const WorkspaceForm = ({
   defaultValues,
   opType,
   permissionEnabled,
-  permissionFirstUserDeletable,
+  permissionLastAdminItemDeletable,
 }: WorkspaceFormProps) => {
   const applications = useApplications(application);
   const workspaceNameReadOnly = defaultValues?.reserved;
@@ -687,7 +687,7 @@ export const WorkspaceForm = ({
             errors={formErrors.permissions}
             onChange={setPermissionSettings}
             permissionSettings={permissionSettings}
-            firstUserDeletable={permissionFirstUserDeletable}
+            lastAdminItemDeletable={!!permissionLastAdminItemDeletable}
             data-test-subj={`workspaceForm-permissionSettingPanel`}
           />
         </EuiPanel>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_permission_setting_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_permission_setting_panel.tsx
@@ -112,11 +112,11 @@ interface WorkspacePermissionSettingInputProps {
 
 const WorkspacePermissionSettingInput = ({
   index,
-  deletable,
   type,
   userId,
   group,
   modes,
+  deletable,
   onDelete,
   onGroupOrUserIdChange,
   onPermissionModesChange,
@@ -201,13 +201,15 @@ const WorkspacePermissionSettingInput = ({
 
 interface WorkspacePermissionSettingPanelProps {
   errors?: string[];
-  firstUserDeletable?: boolean;
+  lastAdminItemDeletable: boolean;
   permissionSettings: Array<Partial<WorkspacePermissionSetting>>;
   onChange?: (value: Array<Partial<WorkspacePermissionSetting>>) => void;
 }
 
-interface UserOrGroupSectionProps extends WorkspacePermissionSettingPanelProps {
+interface UserOrGroupSectionProps
+  extends Omit<WorkspacePermissionSettingPanelProps, 'lastAdminItemDeletable'> {
   title: string;
+  nonDeletableIndex: number;
   type: WorkspacePermissionItemType;
 }
 
@@ -217,7 +219,7 @@ const UserOrGroupSection = ({
   errors,
   onChange,
   permissionSettings,
-  firstUserDeletable,
+  nonDeletableIndex,
 }: UserOrGroupSectionProps) => {
   const transformedValue = useMemo(() => {
     if (!permissionSettings) {
@@ -315,9 +317,7 @@ const UserOrGroupSection = ({
               {...item}
               type={type}
               index={index}
-              deletable={
-                type === WorkspacePermissionItemType.Group || firstUserDeletable || index !== 0
-              }
+              deletable={index !== nonDeletableIndex}
               onDelete={handleDelete}
               onGroupOrUserIdChange={handleGroupOrUserIdChange}
               onPermissionModesChange={handlePermissionModesChange}
@@ -343,7 +343,7 @@ export const WorkspacePermissionSettingPanel = ({
   errors,
   onChange,
   permissionSettings,
-  firstUserDeletable,
+  lastAdminItemDeletable,
 }: WorkspacePermissionSettingPanelProps) => {
   const [userPermissionSettings, setUserPermissionSettings] = useState<
     Array<Partial<WorkspacePermissionSetting>>
@@ -359,10 +359,36 @@ export const WorkspacePermissionSettingPanel = ({
       (permissionSettingItem) => permissionSettingItem.type === WorkspacePermissionItemType.Group
     ) ?? []
   );
+  const [userNonDeletableIndex, setUserNonDeletableIndex] = useState<number>(-1);
+  const [groupNonDeletableIndex, setGroupNonDeletableIndex] = useState<number>(-1);
 
   useEffect(() => {
-    onChange?.([...userPermissionSettings, ...groupPermissionSettings]);
-  }, [onChange, userPermissionSettings, groupPermissionSettings]);
+    const newPermissionSettings = [...userPermissionSettings, ...groupPermissionSettings];
+    onChange?.(newPermissionSettings);
+    if (!lastAdminItemDeletable) {
+      const adminPermissionSettings = newPermissionSettings.filter(
+        (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
+      );
+      if (adminPermissionSettings.length === 1) {
+        if (adminPermissionSettings[0].type === WorkspacePermissionItemType.User) {
+          setUserNonDeletableIndex(
+            userPermissionSettings.findIndex(
+              (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
+            )
+          );
+        } else {
+          setGroupNonDeletableIndex(
+            groupPermissionSettings.findIndex(
+              (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
+            )
+          );
+        }
+        return;
+      }
+    }
+    setUserNonDeletableIndex(-1);
+    setGroupNonDeletableIndex(-1);
+  }, [onChange, userPermissionSettings, groupPermissionSettings, lastAdminItemDeletable]);
 
   return (
     <div>
@@ -372,8 +398,8 @@ export const WorkspacePermissionSettingPanel = ({
         })}
         errors={errors}
         onChange={setUserPermissionSettings}
+        nonDeletableIndex={userNonDeletableIndex}
         permissionSettings={userPermissionSettings}
-        firstUserDeletable={firstUserDeletable}
         type={WorkspacePermissionItemType.User}
       />
       <EuiSpacer size="s" />
@@ -383,6 +409,7 @@ export const WorkspacePermissionSettingPanel = ({
         })}
         errors={errors}
         onChange={setGroupPermissionSettings}
+        nonDeletableIndex={groupNonDeletableIndex}
         permissionSettings={groupPermissionSettings}
         type={WorkspacePermissionItemType.Group}
       />

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_permission_setting_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_permission_setting_panel.tsx
@@ -359,36 +359,35 @@ export const WorkspacePermissionSettingPanel = ({
       (permissionSettingItem) => permissionSettingItem.type === WorkspacePermissionItemType.Group
     ) ?? []
   );
-  const [userNonDeletableIndex, setUserNonDeletableIndex] = useState<number>(-1);
-  const [groupNonDeletableIndex, setGroupNonDeletableIndex] = useState<number>(-1);
 
   useEffect(() => {
+    onChange?.([...userPermissionSettings, ...groupPermissionSettings]);
+  }, [onChange, userPermissionSettings, groupPermissionSettings]);
+
+  const nonDeletableIndex = useMemo(() => {
+    let userNonDeletableIndex = -1;
+    let groupNonDeletableIndex = -1;
     const newPermissionSettings = [...userPermissionSettings, ...groupPermissionSettings];
-    onChange?.(newPermissionSettings);
     if (!lastAdminItemDeletable) {
       const adminPermissionSettings = newPermissionSettings.filter(
         (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
       );
       if (adminPermissionSettings.length === 1) {
         if (adminPermissionSettings[0].type === WorkspacePermissionItemType.User) {
-          setUserNonDeletableIndex(
-            userPermissionSettings.findIndex(
-              (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
-            )
+          userNonDeletableIndex = userPermissionSettings.findIndex(
+            (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
           );
         } else {
-          setGroupNonDeletableIndex(
-            groupPermissionSettings.findIndex(
-              (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
-            )
+          groupNonDeletableIndex = groupPermissionSettings.findIndex(
+            (permission) => getPermissionModeId(permission.modes ?? []) === PermissionModeId.Admin
           );
         }
-        return;
       }
     }
-    setUserNonDeletableIndex(-1);
-    setGroupNonDeletableIndex(-1);
-  }, [onChange, userPermissionSettings, groupPermissionSettings, lastAdminItemDeletable]);
+    return { userNonDeletableIndex, groupNonDeletableIndex };
+  }, [userPermissionSettings, groupPermissionSettings, lastAdminItemDeletable]);
+
+  const { userNonDeletableIndex, groupNonDeletableIndex } = nonDeletableIndex;
 
   return (
     <div>


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

In workspace update page, users cannot delete the last user or group with admin permission.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
