### PR TITLE
Add simple string query flags options to find method

### DIFF
--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -373,6 +373,7 @@ export class SavedObjectsClient {
       namespaces: 'namespaces',
       preference: 'preference',
       workspaces: 'workspaces',
+      flags: 'flags',
     };
 
     const currentWorkspaceId = this._getCurrentWorkspace();

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -888,6 +888,7 @@ export class SavedObjectsRepository {
       preference,
       workspaces,
       ACLSearchParams,
+      flags,
     } = options;
 
     if (!type && !typeToNamespacesMap) {
@@ -963,6 +964,7 @@ export class SavedObjectsRepository {
           kueryNode,
           workspaces,
           ACLSearchParams,
+          flags,
         }),
       },
     };

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
@@ -506,6 +506,25 @@ describe('#getQueryParams', () => {
           );
         });
       });
+
+      describe('`flags` parameter', () => {
+        it('does not include flags when `flags` is not specified', () => {
+          const result = getQueryParams({
+            registry,
+            search,
+          });
+          expectResult(result, expect.not.objectContaining({ flags: expect.anything() }));
+        });
+
+        it('includes flags when specified', () => {
+          const result = getQueryParams({
+            registry,
+            search,
+            flags: 'abc',
+          });
+          expectResult(result, expect.objectContaining({ flags: expect.stringMatching('abc') }));
+        });
+      });
     });
 
     describe('when using prefix search (query.bool.should)', () => {

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -168,6 +168,7 @@ interface QueryParams {
   kueryNode?: KueryNode;
   workspaces?: string[];
   ACLSearchParams?: SavedObjectsFindOptions['ACLSearchParams'];
+  flags?: string;
 }
 
 export function getClauseForReference(reference: HasReferenceQueryParams) {
@@ -226,6 +227,7 @@ export function getQueryParams({
   kueryNode,
   workspaces,
   ACLSearchParams,
+  flags,
 }: QueryParams) {
   const types = getTypes(
     registry,
@@ -269,6 +271,7 @@ export function getQueryParams({
       searchFields,
       rootSearchFields,
       defaultSearchOperator,
+      flags,
     });
 
     if (useMatchPhrasePrefix) {
@@ -417,18 +420,21 @@ const getSimpleQueryStringClause = ({
   searchFields,
   rootSearchFields,
   defaultSearchOperator,
+  flags,
 }: {
   search: string;
   types: string[];
   searchFields?: string[];
   rootSearchFields?: string[];
   defaultSearchOperator?: string;
+  flags?: string;
 }) => {
   return {
     simple_query_string: {
       query: search,
       ...getSimpleQueryStringTypeFields(types, searchFields, rootSearchFields),
       ...(defaultSearchOperator ? { default_operator: defaultSearchOperator } : {}),
+      ...(flags ? { flags } : {}),
     },
   };
 };

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -55,6 +55,7 @@ interface GetSearchDslOptions {
   kueryNode?: KueryNode;
   workspaces?: string[];
   ACLSearchParams?: SavedObjectsFindOptions['ACLSearchParams'];
+  flags?: string;
 }
 
 export function getSearchDsl(
@@ -76,6 +77,7 @@ export function getSearchDsl(
     kueryNode,
     workspaces,
     ACLSearchParams,
+    flags,
   } = options;
 
   if (!type) {
@@ -100,6 +102,7 @@ export function getSearchDsl(
       kueryNode,
       workspaces,
       ACLSearchParams,
+      flags,
     }),
     ...getSortingParams(mappings, type, sortField, sortOrder),
   };

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -92,6 +92,8 @@ export interface SavedObjectsFindOptions {
   search?: string;
   /** The fields to perform the parsed query against. See OpenSearch Simple Query String `fields` argument for more information */
   searchFields?: string[];
+  /** The enabled operators for OpenSearch Simple Query String. See OpenSearch Simple Query String `flags` argument for more information */
+  flags?: string;
   /**
    * The fields to perform the parsed query against. Unlike the `searchFields` argument, these are expected to be root fields and will not
    * be modified. If used in conjunction with `searchFields`, both are concatenated together.

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -202,6 +202,7 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
           type: WORKSPACE_TYPE,
           search: attributes.name,
           searchFields: ['name'],
+          flags: 'NONE', // disable all operators, treat workspace as literal string
         }
       );
       if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
@@ -353,6 +354,7 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
           search: attributes.name,
           searchFields: ['name'],
           fields: ['_id'],
+          flags: 'NONE', // disable all operators, treat workspace as literal string
         });
         if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
           throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);


### PR DESCRIPTION
### Description

Add an new option `flag` for find method which is used for simple query string limit operators.

with `flags` as `NONE`, all reserved keyword for simple query string will treated as literal string.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
