### PR TITLE
feat: add workspace into includeHiddenTypes

### DIFF
--- a/src/plugins/workspace/server/permission_control/client.ts
+++ b/src/plugins/workspace/server/permission_control/client.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { i18n } from '@osd/i18n';
-import { OpenSearchDashboardsRequest, Principals, SavedObject } from '../../../../core/server';
+import {
+  OpenSearchDashboardsRequest,
+  Principals,
+  SavedObject,
+  WORKSPACE_TYPE,
+} from '../../../../core/server';
 import {
   ACL,
   TransformedPermission,
@@ -27,6 +32,7 @@ export class SavedObjectsPermissionControl {
   private getScopedClient(request: OpenSearchDashboardsRequest) {
     return this._getScopedClient?.(request, {
       excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+      includedHiddenTypes: [WORKSPACE_TYPE],
     });
   }
 

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -31,6 +31,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
   private client?: IWorkspaceClientImpl;
   private permissionControl?: SavedObjectsPermissionControlContract;
   private readonly config$: Observable<ConfigSchema>;
+  private workspaceSavedObjectsClientWrapper?: WorkspaceSavedObjectsClientWrapper;
 
   private proxyWorkspaceTrafficToRealHandler(setupDeps: CoreSetup) {
     /**
@@ -72,14 +73,14 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         permissionControl: this.permissionControl,
       });
 
-      const workspaceSavedObjectsClientWrapper = new WorkspaceSavedObjectsClientWrapper(
+      this.workspaceSavedObjectsClientWrapper = new WorkspaceSavedObjectsClientWrapper(
         this.permissionControl
       );
 
       core.savedObjects.addClientWrapper(
         0,
         WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
-        workspaceSavedObjectsClientWrapper.wrapperFactory
+        this.workspaceSavedObjectsClientWrapper.wrapperFactory
       );
     }
 
@@ -93,11 +94,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
 
     core.savedObjects.setClientFactoryProvider(
       (repositoryFactory) => ({ includedHiddenTypes }: { includedHiddenTypes?: string[] }) =>
-        new SavedObjectsClient(
-          repositoryFactory.createInternalRepository([
-            ...new Set([WORKSPACE_TYPE, ...(includedHiddenTypes || [])]),
-          ])
-        )
+        new SavedObjectsClient(repositoryFactory.createInternalRepository(includedHiddenTypes))
     );
 
     core.capabilities.registerProvider(() => ({
@@ -116,6 +113,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
     this.logger.debug('Starting SavedObjects service');
     this.permissionControl?.setup(core.savedObjects.getScopedClient);
     this.client?.setSavedObjects(core.savedObjects);
+    this.workspaceSavedObjectsClientWrapper?.setScopedClient(core.savedObjects.getScopedClient);
 
     return {
       client: this.client as IWorkspaceClientImpl,

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -11,6 +11,7 @@ import {
   Plugin,
   Logger,
   SavedObjectsClient,
+  WORKSPACE_TYPE,
 } from '../../../core/server';
 import { IWorkspaceClientImpl } from './types';
 import { WorkspaceClientWithSavedObject } from './workspace_client';
@@ -92,7 +93,11 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
 
     core.savedObjects.setClientFactoryProvider(
       (repositoryFactory) => ({ includedHiddenTypes }: { includedHiddenTypes?: string[] }) =>
-        new SavedObjectsClient(repositoryFactory.createInternalRepository(includedHiddenTypes))
+        new SavedObjectsClient(
+          repositoryFactory.createInternalRepository([
+            ...new Set([WORKSPACE_TYPE, ...(includedHiddenTypes || [])]),
+          ])
+        )
     );
 
     core.capabilities.registerProvider(() => ({


### PR DESCRIPTION
### Description

Regarding PR https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5075, we will make workspace as a hidden type so that it won't be modified by normal saved objects client. So that we'd have to include workspace as hidden types of saved objects wrapper and saved objects permission control service.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
