### PR TITLE
Add permissions field to mapping when the feature flag is enabled

### DIFF
--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -90,6 +90,9 @@ export const config = {
         defaultValue: 'https://survey.opensearch.org',
       }),
     }),
+    permission: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    }),
   }),
   deprecations,
 };

--- a/src/core/server/saved_objects/migrations/core/migration_context.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_context.ts
@@ -59,6 +59,7 @@ export interface MigrationOpts {
   documentMigrator: VersionedTransformer;
   serializer: SavedObjectsSerializer;
   convertToAliasScript?: string;
+  permissionControlEnabled?: boolean;
 
   /**
    * If specified, templates matching the specified pattern will be removed
@@ -93,7 +94,12 @@ export async function migrationContext(opts: MigrationOpts): Promise<Context> {
   const { log, client } = opts;
   const alias = opts.index;
   const source = createSourceContext(await Index.fetchInfo(client, alias), alias);
-  const dest = createDestContext(source, alias, opts.mappingProperties);
+  const dest = createDestContext(
+    source,
+    alias,
+    opts.mappingProperties,
+    opts.permissionControlEnabled
+  );
 
   return {
     client,
@@ -125,10 +131,11 @@ function createSourceContext(source: Index.FullIndexInfo, alias: string) {
 function createDestContext(
   source: Index.FullIndexInfo,
   alias: string,
-  typeMappingDefinitions: SavedObjectsTypeMappingDefinitions
+  typeMappingDefinitions: SavedObjectsTypeMappingDefinitions,
+  permissionControlEnabled?: boolean
 ): Index.FullIndexInfo {
   const targetMappings = disableUnknownTypeMappingFields(
-    buildActiveMappings(typeMappingDefinitions),
+    buildActiveMappings(typeMappingDefinitions, permissionControlEnabled),
     source.mappings
   );
 

--- a/src/core/server/saved_objects/saved_objects_config.ts
+++ b/src/core/server/saved_objects/saved_objects_config.ts
@@ -49,12 +49,16 @@ export const savedObjectsConfig = {
   schema: schema.object({
     maxImportPayloadBytes: schema.byteSize({ defaultValue: 26214400 }),
     maxImportExportSize: schema.byteSize({ defaultValue: 10000 }),
+    permission: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    }),
   }),
 };
 
 export class SavedObjectConfig {
   public maxImportPayloadBytes: number;
   public maxImportExportSize: number;
+  public permissionControlEnabled: boolean;
 
   public migration: SavedObjectsMigrationConfigType;
 
@@ -65,5 +69,6 @@ export class SavedObjectConfig {
     this.maxImportPayloadBytes = rawConfig.maxImportPayloadBytes.getValueInBytes();
     this.maxImportExportSize = rawConfig.maxImportExportSize.getValueInBytes();
     this.migration = rawMigrationConfig;
+    this.permissionControlEnabled = rawConfig.permission.enabled;
   }
 }

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -433,7 +433,7 @@ export class SavedObjectsService
 
     const migrator = this.createMigrator(
       opensearchDashboardsConfig,
-      this.config.migration,
+      this.config,
       opensearch.client,
       migrationsRetryDelay
     );
@@ -544,7 +544,7 @@ export class SavedObjectsService
 
   private createMigrator(
     opensearchDashboardsConfig: OpenSearchDashboardsConfigType,
-    savedObjectsConfig: SavedObjectsMigrationConfigType,
+    savedObjectsConfig: SavedObjectConfig,
     client: IClusterClient,
     migrationsRetryDelay?: number
   ): IOpenSearchDashboardsMigrator {


### PR DESCRIPTION
### Description

This PR is to:
1. Add a new yml config called `savedObjects.permission.enabled` which control whether the permission control feature for saved objects is enabled or not, defaults to false.
2. When the permission control flag is enabled, add `permissions` field to the mapping of the OSD index `.kibana`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
