### PR TITLE
Add a workspace dropdown menu in left navigation bar

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -105,6 +105,7 @@ export {
   StringValidationRegex,
   StringValidationRegexString,
   WorkspaceObject,
+  WorkspaceAttribute,
 } from '../types';
 
 export {

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -354,4 +354,4 @@ export { __osdBootstrap__ } from './osd_bootstrap';
 
 export { WorkspacesStart, WorkspacesSetup, WorkspacesService } from './workspace';
 
-export { WORKSPACE_TYPE } from '../utils';
+export { WORKSPACE_TYPE, cleanWorkspaceId } from '../utils';

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -74,6 +74,7 @@ function createCoreSetupMock({
 } = {}) {
   const mock = {
     application: applicationServiceMock.createSetupContract(),
+    chrome: chromeServiceMock.createSetupContract(),
     context: contextServiceMock.createSetupContract(),
     docLinks: docLinksServiceMock.createSetupContract(),
     fatalErrors: fatalErrorsServiceMock.createSetupContract(),

--- a/src/core/public/utils/index.ts
+++ b/src/core/public/utils/index.ts
@@ -36,4 +36,5 @@ export {
   WORKSPACE_TYPE,
   formatUrlWithWorkspaceId,
   getWorkspaceIdFromUrl,
+  cleanWorkspaceId,
 } from '../../utils';

--- a/src/core/public/workspace/workspaces_service.mock.ts
+++ b/src/core/public/workspace/workspaces_service.mock.ts
@@ -8,24 +8,31 @@ import type { PublicMethodsOf } from '@osd/utility-types';
 import { WorkspacesService } from './workspaces_service';
 import { WorkspaceObject } from '..';
 
-const currentWorkspaceId$ = new BehaviorSubject<string>('');
-const workspaceList$ = new BehaviorSubject<WorkspaceObject[]>([]);
-const currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(null);
-const initialized$ = new BehaviorSubject<boolean>(false);
+const createWorkspacesSetupContractMock = () => {
+  const currentWorkspaceId$ = new BehaviorSubject<string>('');
+  const workspaceList$ = new BehaviorSubject<WorkspaceObject[]>([]);
+  const currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(null);
+  const initialized$ = new BehaviorSubject<boolean>(false);
+  return {
+    currentWorkspaceId$,
+    workspaceList$,
+    currentWorkspace$,
+    initialized$,
+  };
+};
 
-const createWorkspacesSetupContractMock = () => ({
-  currentWorkspaceId$,
-  workspaceList$,
-  currentWorkspace$,
-  initialized$,
-});
-
-const createWorkspacesStartContractMock = () => ({
-  currentWorkspaceId$,
-  workspaceList$,
-  currentWorkspace$,
-  initialized$,
-});
+const createWorkspacesStartContractMock = () => {
+  const currentWorkspaceId$ = new BehaviorSubject<string>('');
+  const workspaceList$ = new BehaviorSubject<WorkspaceObject[]>([]);
+  const currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(null);
+  const initialized$ = new BehaviorSubject<boolean>(false);
+  return {
+    currentWorkspaceId$,
+    workspaceList$,
+    currentWorkspace$,
+    initialized$,
+  };
+};
 
 export type WorkspacesServiceContract = PublicMethodsOf<WorkspacesService>;
 const createMock = (): jest.Mocked<WorkspacesServiceContract> => ({

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const WORKSPACE_CREATE_APP_ID = 'workspace_create';
+export const WORKSPACE_LIST_APP_ID = 'workspace_list';
 export const WORKSPACE_UPDATE_APP_ID = 'workspace_update';
 export const WORKSPACE_OVERVIEW_APP_ID = 'workspace_overview';
 export const WORKSPACE_FATAL_ERROR_APP_ID = 'workspace_fatal_error';

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { WorkspaceMenu } from './workspace_menu';
+import { coreMock } from '../../../../../core/public/mocks';
+import { CoreStart } from '../../../../../core/public';
+
+describe('<WorkspaceMenu />', () => {
+  let coreStartMock: CoreStart;
+
+  beforeEach(() => {
+    coreStartMock = coreMock.createStart();
+    coreStartMock.workspaces.initialized$.next(true);
+    jest.spyOn(coreStartMock.application, 'getUrlForApp').mockImplementation((appId: string) => {
+      return `https://test.com/app/${appId}`;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('should display a list of workspaces in the dropdown', () => {
+    coreStartMock.workspaces.workspaceList$.next([
+      { id: 'workspace-1', name: 'workspace 1' },
+      { id: 'workspace-2', name: 'workspace 2' },
+    ]);
+
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    fireEvent.click(screen.getByText(/select a workspace/i));
+
+    expect(screen.getByText(/workspace 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/workspace 2/i)).toBeInTheDocument();
+  });
+
+  it('should display current workspace name', () => {
+    coreStartMock.workspaces.currentWorkspace$.next({ id: 'workspace-1', name: 'workspace 1' });
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    expect(screen.getByText(/workspace 1/i)).toBeInTheDocument();
+  });
+
+  it('should close the workspace dropdown list', async () => {
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    fireEvent.click(screen.getByText(/select a workspace/i));
+
+    expect(screen.getByLabelText(/close workspace dropdown/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/close workspace dropdown/i));
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/close workspace dropdown/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('should navigate to the workspace', () => {
+    coreStartMock.workspaces.workspaceList$.next([
+      { id: 'workspace-1', name: 'workspace 1' },
+      { id: 'workspace-2', name: 'workspace 2' },
+    ]);
+
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: jest.fn(),
+      },
+    });
+
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    fireEvent.click(screen.getByText(/select a workspace/i));
+    fireEvent.click(screen.getByText(/workspace 1/i));
+
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://test.com/w/workspace-1/app/workspace_overview'
+    );
+
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+    });
+  });
+
+  it('should navigate to create workspace page', () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: jest.fn(),
+      },
+    });
+
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    fireEvent.click(screen.getByText(/select a workspace/i));
+    fireEvent.click(screen.getByText(/create workspace/i));
+    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_create');
+
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+    });
+  });
+
+  it('should navigate to workspace list page', () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: jest.fn(),
+      },
+    });
+
+    render(<WorkspaceMenu coreStart={coreStartMock} />);
+    fireEvent.click(screen.getByText(/select a workspace/i));
+    fireEvent.click(screen.getByText(/all workspace/i));
+    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_list');
+
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+    });
+  });
+});

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -19,14 +19,13 @@ import {
 } from '@elastic/eui';
 import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
 
-import { WorkspaceAttribute } from '../../../../../core/public';
 import {
   WORKSPACE_CREATE_APP_ID,
   WORKSPACE_LIST_APP_ID,
   WORKSPACE_OVERVIEW_APP_ID,
 } from '../../../common/constants';
-import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
-import { CoreStart } from '../../../../../core/public';
+import { cleanWorkspaceId, formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
+import { CoreStart, WorkspaceAttribute } from '../../../../../core/public';
 
 interface Props {
   coreStart: CoreStart;
@@ -36,7 +35,7 @@ function getFilteredWorkspaceList(
   workspaceList: WorkspaceAttribute[],
   currentWorkspace: WorkspaceAttribute | null
 ): WorkspaceAttribute[] {
-  // list top5 workspaces except management workspace, place current workspace at the top
+  // list top5 workspaces and place the current workspace at the top
   return [
     ...(currentWorkspace ? [currentWorkspace] : []),
     ...workspaceList.filter((workspace) => workspace.id !== currentWorkspace?.id),
@@ -83,7 +82,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       );
     return {
       name,
-      key: index.toString(),
+      key: workspace.id,
       icon: <EuiIcon type="stopFilled" color={workspace.color ?? 'primary'} />,
       onClick: () => {
         window.location.assign(workspaceURL);
@@ -95,18 +94,19 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
     const workspaceListItems: EuiContextMenuPanelItemDescriptor[] = filteredWorkspaceList.map(
       (workspace, index) => workspaceToItem(workspace, index)
     );
-    const length = workspaceListItems.length;
     workspaceListItems.push({
       icon: <EuiIcon type="plus" />,
       name: i18n.translate('core.ui.primaryNav.workspaceContextMenu.createWorkspace', {
         defaultMessage: 'Create workspace',
       }),
-      key: length.toString(),
+      key: WORKSPACE_CREATE_APP_ID,
       onClick: () => {
         window.location.assign(
-          coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
-            absolute: false,
-          })
+          cleanWorkspaceId(
+            coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
+              absolute: false,
+            })
+          )
         );
       },
     });
@@ -115,12 +115,14 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       name: i18n.translate('core.ui.primaryNav.workspaceContextMenu.allWorkspace', {
         defaultMessage: 'All workspaces',
       }),
-      key: (length + 1).toString(),
+      key: WORKSPACE_LIST_APP_ID,
       onClick: () => {
         window.location.assign(
-          coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
-            absolute: false,
-          })
+          cleanWorkspaceId(
+            coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
+              absolute: false,
+            })
+          )
         );
       },
     });

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -25,16 +25,16 @@ import {
   WORKSPACE_OVERVIEW_APP_ID,
 } from '../../../common/constants';
 import { cleanWorkspaceId, formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
-import { CoreStart, WorkspaceAttribute } from '../../../../../core/public';
+import { CoreStart, WorkspaceObject } from '../../../../../core/public';
 
 interface Props {
   coreStart: CoreStart;
 }
 
 function getFilteredWorkspaceList(
-  workspaceList: WorkspaceAttribute[],
-  currentWorkspace: WorkspaceAttribute | null
-): WorkspaceAttribute[] {
+  workspaceList: WorkspaceObject[],
+  currentWorkspace: WorkspaceObject | null
+): WorkspaceObject[] {
   // list top5 workspaces and place the current workspace at the top
   return [
     ...(currentWorkspace ? [currentWorkspace] : []),
@@ -56,7 +56,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
   const filteredWorkspaceList = getFilteredWorkspaceList(workspaceList, currentWorkspace);
   const currentWorkspaceName = currentWorkspace?.name ?? defaultHeaderName;
 
-  const onButtonClick = () => {
+  const openPopover = () => {
     setPopover(!isPopoverOpen);
   };
 
@@ -64,7 +64,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
     setPopover(false);
   };
 
-  const workspaceToItem = (workspace: WorkspaceAttribute, index: number) => {
+  const workspaceToItem = (workspace: WorkspaceObject) => {
     const workspaceURL = formatUrlWithWorkspaceId(
       coreStart.application.getUrlForApp(WORKSPACE_OVERVIEW_APP_ID, {
         absolute: false,
@@ -73,7 +73,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       coreStart.http.basePath
     );
     const name =
-      currentWorkspace !== null && index === 0 ? (
+      currentWorkspace?.name === workspace.name ? (
         <EuiText>
           <strong>{workspace.name}</strong>
         </EuiText>
@@ -92,7 +92,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
 
   const getWorkspaceListItems = () => {
     const workspaceListItems: EuiContextMenuPanelItemDescriptor[] = filteredWorkspaceList.map(
-      (workspace, index) => workspaceToItem(workspace, index)
+      workspaceToItem
     );
     workspaceListItems.push({
       icon: <EuiIcon type="plus" />,
@@ -135,10 +135,10 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
         <EuiListGroupItem
           iconType="spacesApp"
           label={currentWorkspaceName}
-          onClick={onButtonClick}
+          onClick={openPopover}
           extraAction={{
             color: 'subdued',
-            onClick: onButtonClick,
+            onClick: openPopover,
             iconType: isPopoverOpen ? 'arrowDown' : 'arrowRight',
             iconSize: 's',
             'aria-label': 'Show workspace dropdown selector',
@@ -175,6 +175,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
   return (
     <EuiPopover
       id="contextMenuExample"
+      display="block"
       button={currentWorkspaceButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import React, { useState } from 'react';
+import { useObservable } from 'react-use';
+import {
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiListGroup,
+  EuiListGroupItem,
+  EuiPopover,
+  EuiText,
+} from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+
+import { WorkspaceAttribute } from '../../../../../core/public';
+import {
+  WORKSPACE_CREATE_APP_ID,
+  WORKSPACE_LIST_APP_ID,
+  WORKSPACE_OVERVIEW_APP_ID,
+} from '../../../common/constants';
+import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
+import { CoreStart } from '../../../../../core/public';
+
+interface Props {
+  coreStart: CoreStart;
+}
+
+function getFilteredWorkspaceList(
+  workspaceList: WorkspaceAttribute[],
+  currentWorkspace: WorkspaceAttribute | null
+): WorkspaceAttribute[] {
+  // list top5 workspaces except management workspace, place current workspace at the top
+  return [
+    ...(currentWorkspace ? [currentWorkspace] : []),
+    ...workspaceList.filter((workspace) => workspace.id !== currentWorkspace?.id),
+  ].slice(0, 5);
+}
+
+export const WorkspaceMenu = ({ coreStart }: Props) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
+  const workspaceList = useObservable(coreStart.workspaces.workspaceList$, []);
+
+  const defaultHeaderName = i18n.translate(
+    'core.ui.primaryNav.workspacePickerMenu.defaultHeaderName',
+    {
+      defaultMessage: 'Select a workspace',
+    }
+  );
+  const filteredWorkspaceList = getFilteredWorkspaceList(workspaceList, currentWorkspace);
+  const currentWorkspaceName = currentWorkspace?.name ?? defaultHeaderName;
+
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
+  };
+
+  const closePopover = () => {
+    setPopover(false);
+  };
+
+  const workspaceToItem = (workspace: WorkspaceAttribute, index: number) => {
+    const workspaceURL = formatUrlWithWorkspaceId(
+      coreStart.application.getUrlForApp(WORKSPACE_OVERVIEW_APP_ID, {
+        absolute: false,
+      }),
+      workspace.id,
+      coreStart.http.basePath
+    );
+    const name =
+      currentWorkspace !== null && index === 0 ? (
+        <EuiText>
+          <strong>{workspace.name}</strong>
+        </EuiText>
+      ) : (
+        workspace.name
+      );
+    return {
+      name,
+      key: index.toString(),
+      icon: <EuiIcon type="stopFilled" color={workspace.color ?? 'primary'} />,
+      onClick: () => {
+        window.location.assign(workspaceURL);
+      },
+    };
+  };
+
+  const getWorkspaceListItems = () => {
+    const workspaceListItems: EuiContextMenuPanelItemDescriptor[] = filteredWorkspaceList.map(
+      (workspace, index) => workspaceToItem(workspace, index)
+    );
+    const length = workspaceListItems.length;
+    workspaceListItems.push({
+      icon: <EuiIcon type="plus" />,
+      name: i18n.translate('core.ui.primaryNav.workspaceContextMenu.createWorkspace', {
+        defaultMessage: 'Create workspace',
+      }),
+      key: length.toString(),
+      onClick: () => {
+        window.location.assign(
+          coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
+            absolute: false,
+          })
+        );
+      },
+    });
+    workspaceListItems.push({
+      icon: <EuiIcon type="folderClosed" />,
+      name: i18n.translate('core.ui.primaryNav.workspaceContextMenu.allWorkspace', {
+        defaultMessage: 'All workspaces',
+      }),
+      key: (length + 1).toString(),
+      onClick: () => {
+        window.location.assign(
+          coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
+            absolute: false,
+          })
+        );
+      },
+    });
+    return workspaceListItems;
+  };
+
+  const currentWorkspaceButton = (
+    <>
+      <EuiListGroup style={{ width: 318 }} maxWidth={false}>
+        <EuiListGroupItem
+          iconType="spacesApp"
+          label={currentWorkspaceName}
+          onClick={onButtonClick}
+          extraAction={{
+            color: 'subdued',
+            onClick: onButtonClick,
+            iconType: isPopoverOpen ? 'arrowDown' : 'arrowRight',
+            iconSize: 's',
+            'aria-label': 'Show workspace dropdown selector',
+            alwaysShow: true,
+          }}
+        />
+      </EuiListGroup>
+    </>
+  );
+
+  const currentWorkspaceTitle = (
+    <EuiFlexGroup alignItems="center">
+      <EuiFlexItem grow={true}>
+        <EuiText size="s">{currentWorkspaceName}</EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType="cross"
+          onClick={closePopover}
+          aria-label="close workspace dropdown"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const panels = [
+    {
+      id: 0,
+      title: currentWorkspaceTitle,
+      items: getWorkspaceListItems(),
+    },
+  ];
+
+  return (
+    <EuiPopover
+      id="contextMenuExample"
+      button={currentWorkspaceButton}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downCenter"
+    >
+      <EuiContextMenu initialPanelId={0} panels={panels} />
+    </EuiPopover>
+  );
+};

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -149,4 +149,11 @@ describe('Workspace plugin', () => {
     coreStart.workspaces.currentWorkspaceId$.next('foo');
     expect(coreStart.savedObjects.client.setCurrentWorkspace).toHaveBeenCalledWith('foo');
   });
+
+  it('#setup register workspace dropdown menu when setup', async () => {
+    const setupMock = coreMock.createSetup();
+    const workspacePlugin = new WorkspacePlugin();
+    await workspacePlugin.setup(setupMock);
+    expect(setupMock.chrome.registerCollapsibleNavHeader).toBeCalledTimes(1);
+  });
 });

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../core/public';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { getWorkspaceIdFromUrl } from '../../../core/public/utils';
+import { renderWorkspaceMenu } from './render_workspace_menu';
 import { Services } from './types';
 import { WorkspaceClient } from './workspace_client';
 
@@ -147,6 +148,16 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         const { renderFatalErrorApp } = await import('./application');
         return mountWorkspaceApp(params, renderFatalErrorApp);
       },
+    });
+
+    /**
+     * Register workspace dropdown selector on the top of left navigation menu
+     */
+    core.chrome.registerCollapsibleNavHeader(() => {
+      if (!this.coreStart) {
+        return null;
+      }
+      return renderWorkspaceMenu(this.coreStart);
     });
 
     return {};

--- a/src/plugins/workspace/public/render_workspace_menu.tsx
+++ b/src/plugins/workspace/public/render_workspace_menu.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { CoreStart } from '../../../core/public';
+import { WorkspaceMenu } from './components/workspace_menu/workspace_menu';
+
+export function renderWorkspaceMenu(coreStart: CoreStart) {
+  return <WorkspaceMenu coreStart={coreStart} />;
+}


### PR DESCRIPTION
In this commit, the workspace plugin registered a workspace dropdown menu on the top of left navigation bar. This allows user to quickly switch the current workspace.

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
