### PR TITLE
Add enabledOperators parameter for workspace name unique check

### DIFF
--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -390,6 +390,7 @@ export class SavedObjectsClient {
       namespaces: 'namespaces',
       preference: 'preference',
       workspaces: 'workspaces',
+      enabledOperators: 'enabledOperators',
     };
 
     const renamedQuery = renameKeys<SavedObjectsFindOptions, any>(renameMap, {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -801,6 +801,7 @@ export class SavedObjectsRepository {
       workspaces,
       workspacesSearchOperator,
       ACLSearchParams,
+      enabledOperators,
     } = options;
 
     if (!type && !typeToNamespacesMap) {
@@ -877,6 +878,7 @@ export class SavedObjectsRepository {
           workspaces,
           workspacesSearchOperator,
           ACLSearchParams,
+          enabledOperators,
         }),
       },
     };

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
@@ -506,6 +506,25 @@ describe('#getQueryParams', () => {
           );
         });
       });
+
+      describe('`enabledOperators` parameter', () => {
+        it('does not include flags when `enabledOperators` is not specified', () => {
+          const result = getQueryParams({
+            registry,
+            search,
+          });
+          expectResult(result, expect.not.objectContaining({ flags: expect.anything() }));
+        });
+
+        it('includes flags when `enabledOperators` specified', () => {
+          const result = getQueryParams({
+            registry,
+            search,
+            enabledOperators: 'all',
+          });
+          expectResult(result, expect.objectContaining({ flags: expect.stringMatching('all') }));
+        });
+      });
     });
 
     describe('when using prefix search (query.bool.should)', () => {

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -170,6 +170,7 @@ interface QueryParams {
   workspaces?: SavedObjectsFindOptions['workspaces'];
   workspacesSearchOperator?: 'AND' | 'OR';
   ACLSearchParams?: SavedObjectsFindOptions['ACLSearchParams'];
+  enabledOperators?: SavedObjectsFindOptions['enabledOperators'];
 }
 
 export function getClauseForReference(reference: HasReferenceQueryParams) {
@@ -229,6 +230,7 @@ export function getQueryParams({
   workspaces,
   workspacesSearchOperator = 'AND',
   ACLSearchParams,
+  enabledOperators,
 }: QueryParams) {
   const types = getTypes(
     registry,
@@ -261,6 +263,7 @@ export function getQueryParams({
       searchFields,
       rootSearchFields,
       defaultSearchOperator,
+      enabledOperators,
     });
 
     if (useMatchPhrasePrefix) {
@@ -432,18 +435,21 @@ const getSimpleQueryStringClause = ({
   searchFields,
   rootSearchFields,
   defaultSearchOperator,
+  enabledOperators,
 }: {
   search: string;
   types: string[];
   searchFields?: string[];
   rootSearchFields?: string[];
   defaultSearchOperator?: string;
+  enabledOperators?: SavedObjectsFindOptions['enabledOperators'];
 }) => {
   return {
     simple_query_string: {
       query: search,
       ...getSimpleQueryStringTypeFields(types, searchFields, rootSearchFields),
       ...(defaultSearchOperator ? { default_operator: defaultSearchOperator } : {}),
+      ...(enabledOperators ? { flags: enabledOperators } : {}),
     },
   };
 };

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -56,6 +56,7 @@ interface GetSearchDslOptions {
   workspaces?: SavedObjectsFindOptions['workspaces'];
   workspacesSearchOperator?: 'AND' | 'OR';
   ACLSearchParams?: SavedObjectsFindOptions['ACLSearchParams'];
+  enabledOperators?: SavedObjectsFindOptions['enabledOperators'];
 }
 
 export function getSearchDsl(
@@ -78,6 +79,7 @@ export function getSearchDsl(
     workspaces,
     workspacesSearchOperator,
     ACLSearchParams,
+    enabledOperators,
   } = options;
 
   if (!type) {
@@ -103,6 +105,7 @@ export function getSearchDsl(
       workspaces,
       workspacesSearchOperator,
       ACLSearchParams,
+      enabledOperators,
     }),
     ...getSortingParams(mappings, type, sortField, sortOrder),
   };

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -92,6 +92,8 @@ export interface SavedObjectsFindOptions {
   search?: string;
   /** The fields to perform the parsed query against. See OpenSearch Simple Query String `fields` argument for more information */
   searchFields?: string[];
+  /** The enabled operators for OpenSearch Simple Query String. See OpenSearch Simple Query String `flags` argument for more information */
+  enabledOperators?: string;
   /**
    * The fields to perform the parsed query against. Unlike the `searchFields` argument, these are expected to be root fields and will not
    * be modified. If used in conjunction with `searchFields`, both are concatenated together.

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -134,6 +134,7 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           type: WORKSPACE_TYPE,
           search: attributes.name,
           searchFields: ['name'],
+          enabledOperators: 'NONE', // disable all operators, treat workspace as literal string
         }
       );
       if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
@@ -260,6 +261,7 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           search: attributes.name,
           searchFields: ['name'],
           fields: ['_id'],
+          enabledOperators: 'NONE', // disable all operators, treat workspace as literal string
         });
         if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
           throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);


### PR DESCRIPTION
### Description

Add enabledOperators parameter for workspace name unique check. The default value for this flag is `ALL` means all operators are supported.


For example we have workspace named `test-workspace` and now we create a new workspace named `test test-workspace` that will match existing `test-workspace` by using simple query string and leads name unique check failed.

```
GET .kibana/_search
{
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "type": {
              "value": "workspace"
            }
          }
        },
        {
          "simple_query_string": {
            "query": "test test-workspace", // this means match name by test or test-workspace
            "fields": [
              "workspace.name"
            ],
            "flags": "ALL"
          }
        }
      ]
    }
  }
}
# test-workspace will return

```


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
