### PR TITLE
[Workspace] Jump to non-workspace url when clicking home icon

### DIFF
--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -46,6 +46,7 @@ import { MockLifecycle } from './test_types';
 import { ApplicationService } from './application_service';
 import { App, PublicAppInfo, AppNavLinkStatus, AppStatus, AppUpdater } from './types';
 import { act } from 'react-dom/test-utils';
+import { workspacesServiceMock } from '../mocks';
 
 const createApp = (props: Partial<App>): App => {
   return {
@@ -68,7 +69,11 @@ describe('#setup()', () => {
       context: contextServiceMock.createSetupContract(),
       redirectTo: jest.fn(),
     };
-    startDeps = { http, overlays: overlayServiceMock.createStartContract() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces: workspacesServiceMock.createStartContract(),
+    };
     service = new ApplicationService();
   });
 
@@ -398,7 +403,11 @@ describe('#start()', () => {
       context: contextServiceMock.createSetupContract(),
       redirectTo: jest.fn(),
     };
-    startDeps = { http, overlays: overlayServiceMock.createStartContract() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces: workspacesServiceMock.createStartContract(),
+    };
     service = new ApplicationService();
   });
 
@@ -869,7 +878,11 @@ describe('#stop()', () => {
       http,
       context: contextServiceMock.createSetupContract(),
     };
-    startDeps = { http, overlays: overlayServiceMock.createStartContract() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces: workspacesServiceMock.createStartContract(),
+    };
     service = new ApplicationService();
   });
 

--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -44,7 +44,14 @@ import { httpServiceMock } from '../http/http_service.mock';
 import { overlayServiceMock } from '../overlays/overlay_service.mock';
 import { MockLifecycle } from './test_types';
 import { ApplicationService } from './application_service';
-import { App, PublicAppInfo, AppNavLinkStatus, AppStatus, AppUpdater } from './types';
+import {
+  App,
+  PublicAppInfo,
+  AppNavLinkStatus,
+  AppStatus,
+  AppUpdater,
+  WorkspaceAccessibility,
+} from './types';
 import { act } from 'react-dom/test-utils';
 import { workspacesServiceMock } from '../mocks';
 
@@ -548,6 +555,32 @@ describe('#start()', () => {
         'http://localhost/base-path/app/app2/deep/link'
       );
     });
+
+    it('creates URL when the app is not accessible in a workspace', async () => {
+      const httpMock = httpServiceMock.createSetupContract({
+        basePath: '/base-path',
+        clientBasePath: '/client-base-path',
+      });
+      const { register } = service.setup({
+        ...setupDeps,
+        http: httpMock,
+      });
+      // register a app that can only be accessed out of a workspace
+      register(
+        Symbol(),
+        createApp({
+          id: 'app1',
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        })
+      );
+      const { getUrlForApp } = await service.start({
+        ...startDeps,
+        http: httpMock,
+      });
+
+      expect(getUrlForApp('app1')).toBe('/base-path/app/app1');
+      expect(getUrlForApp('app2')).toBe('/base-path/client-base-path/app/app2');
+    });
   });
 
   describe('navigateToApp', () => {
@@ -773,6 +806,46 @@ describe('#start()', () => {
           0,
         ]
       `);
+    });
+
+    it('navigate by using window.location.assign if navigate to a app not accessible within a workspace', async () => {
+      // Save the original assign method
+      const originalLocation = window.location;
+      delete (window as any).location;
+
+      // Mocking the window object
+      window.location = {
+        ...originalLocation,
+        assign: jest.fn(),
+      };
+
+      const { register } = service.setup(setupDeps);
+      // register a app that can only be accessed out of a workspace
+      register(
+        Symbol(),
+        createApp({
+          id: 'app1',
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        })
+      );
+      const workspaces = workspacesServiceMock.createStartContract();
+      workspaces.currentWorkspaceId$.next('foo');
+      const http = httpServiceMock.createStartContract({
+        basePath: '/base-path',
+        clientBasePath: '/client-base-path',
+      });
+      const { navigateToApp } = await service.start({
+        ...startDeps,
+        workspaces,
+        http,
+      });
+      await navigateToApp('app1');
+
+      expect(window.location.assign).toBeCalledWith('/base-path/app/app1');
+      await navigateToApp('app2');
+      // assign should not be called
+      expect(window.location.assign).toBeCalledTimes(1);
+      window.location = originalLocation;
     });
 
     describe('when `replace` option is true', () => {

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -260,18 +260,23 @@ export class ApplicationService {
       const currentAppId = this.currentAppId$.value;
       const navigatingToSameApp = currentAppId === appId;
       const shouldNavigate = navigatingToSameApp ? true : await this.shouldNavigate(overlays);
-      const targetApp = applications$.value.get(appId);
-      if (
-        workspaces.currentWorkspaceId$.value &&
-        targetApp?.visibility === AppVisibility.homeOnly
-      ) {
-        // If user is inside a workspace and the target app is homeOnly
-        // refresh the page by doing a hard navigation
-        window.location.assign(getAppUrl(availableMounters, appId, path));
-        return;
-      }
 
       if (shouldNavigate) {
+        const targetApp = applications$.value.get(appId);
+        if (
+          workspaces.currentWorkspaceId$.value &&
+          targetApp?.visibility === AppVisibility.homeOnly
+        ) {
+          // If user is inside a workspace and the target app is homeOnly
+          // refresh the page by doing a hard navigation
+          window.location.assign(
+            http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
+              withoutClientBasePath: true,
+            })
+          );
+          return;
+        }
+
         if (path === undefined) {
           path = applications$.value.get(appId)?.defaultPath;
         }

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -54,6 +54,7 @@ import {
   InternalApplicationStart,
   Mounter,
   NavigateToAppOptions,
+  WorkspaceAccessibility,
 } from './types';
 import { getLeaveAction, isConfirmAction } from './application_leave';
 import { appendAppPath, parseAppUrl, relativeToAbsolute, getAppInfo } from './utils';
@@ -262,8 +263,11 @@ export class ApplicationService {
 
       if (shouldNavigate) {
         const targetApp = applications$.value.get(appId);
-        if (workspaces.currentWorkspaceId$.value && targetApp?.workspaceless) {
-          // If user is inside a workspace and the target app is workspaceless
+        if (
+          workspaces.currentWorkspaceId$.value &&
+          targetApp?.workspaceAccessibility === WorkspaceAccessibility.NO
+        ) {
+          // If user is inside a workspace and the target app is not accessible within a workspace
           // refresh the page by doing a hard navigation
           window.location.assign(
             http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
@@ -310,7 +314,7 @@ export class ApplicationService {
       ) => {
         const targetApp = applications$.value.get(appId);
         const relUrl = http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
-          withoutClientBasePath: targetApp?.workspaceless,
+          withoutClientBasePath: targetApp?.workspaceAccessibility === WorkspaceAccessibility.NO,
         });
         return absolute ? relativeToAbsolute(relUrl) : relUrl;
       },

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -50,7 +50,6 @@ import {
   AppStatus,
   AppUpdatableFields,
   AppUpdater,
-  AppVisibility,
   InternalApplicationSetup,
   InternalApplicationStart,
   Mounter,

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -263,14 +263,12 @@ export class ApplicationService {
 
       if (shouldNavigate) {
         const targetApp = applications$.value.get(appId);
-        if (
-          workspaces.currentWorkspaceId$.value &&
-          targetApp?.visibility === AppVisibility.homeOnly
-        ) {
-          // If user is inside a workspace and the target app is homeOnly
+        if (workspaces.currentWorkspaceId$.value && targetApp?.workspaceless) {
+          // If user is inside a workspace and the target app is workspaceless
           // refresh the page by doing a hard navigation
           window.location.assign(
             http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
+              // Set withoutClientBasePath to true remove the workspace path prefix
               withoutClientBasePath: true,
             })
           );

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -265,7 +265,10 @@ export class ApplicationService {
         workspaces.currentWorkspaceId$.value &&
         targetApp?.visibility === AppVisibility.homeOnly
       ) {
+        // If user is inside a workspace and the target app is homeOnly
+        // refresh the page by doing a hard navigation
         window.location.assign(getAppUrl(availableMounters, appId, path));
+        return;
       }
 
       if (shouldNavigate) {

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -308,7 +308,10 @@ export class ApplicationService {
         appId,
         { path, absolute = false }: { path?: string; absolute?: boolean } = {}
       ) => {
-        const relUrl = http.basePath.prepend(getAppUrl(availableMounters, appId, path));
+        const targetApp = applications$.value.get(appId);
+        const relUrl = http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
+          withoutClientBasePath: targetApp?.workspaceless,
+        });
         return absolute ? relativeToAbsolute(relUrl) : relUrl;
       },
       navigateToApp,

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -54,4 +54,5 @@ export {
   // Internal types
   InternalApplicationSetup,
   InternalApplicationStart,
+  WorkspaceAccessibility,
 } from './types';

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -51,7 +51,6 @@ export {
   AppLeaveConfirmAction,
   NavigateToAppOptions,
   PublicAppInfo,
-  AppVisibility,
   // Internal types
   InternalApplicationSetup,
   InternalApplicationStart,

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -51,6 +51,7 @@ export {
   AppLeaveConfirmAction,
   NavigateToAppOptions,
   PublicAppInfo,
+  AppVisibility,
   // Internal types
   InternalApplicationSetup,
   InternalApplicationStart,

--- a/src/core/public/application/integration_tests/application_service.test.tsx
+++ b/src/core/public/application/integration_tests/application_service.test.tsx
@@ -41,6 +41,7 @@ import { overlayServiceMock } from '../../overlays/overlay_service.mock';
 import { AppMountParameters } from '../types';
 import { Observable } from 'rxjs';
 import { MountPoint } from 'opensearch-dashboards/public';
+import { workspacesServiceMock } from '../../mocks';
 
 const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -67,7 +68,11 @@ describe('ApplicationService', () => {
       context: contextServiceMock.createSetupContract(),
       history: history as any,
     };
-    startDeps = { http, overlays: overlayServiceMock.createStartContract() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces: workspacesServiceMock.createStartContract(),
+    };
     service = new ApplicationService();
   });
 

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -104,6 +104,22 @@ export type AppUpdatableFields = Pick<App, 'status' | 'navLinkStatus' | 'tooltip
 export type AppUpdater = (app: App) => Partial<AppUpdatableFields> | undefined;
 
 /**
+ * Visibilities of the application based on if user is within a workspace
+ *
+ * @public
+ */
+export enum WorkspaceAccessibility {
+  /**
+   * The application is not accessible when user is in a workspace.
+   */
+  NO = 0,
+  /**
+   * The application is only accessible when user is in a workspace.
+   */
+  YES = 1,
+}
+
+/**
  * @public
  */
 export interface App<HistoryLocationState = unknown> {
@@ -249,7 +265,7 @@ export interface App<HistoryLocationState = unknown> {
   /**
    * Prevent the page to be accessible when inside a workspace. Defaults to `false`.
    */
-  workspaceless?: boolean;
+  workspaceAccessibility?: WorkspaceAccessibility;
 }
 
 /**

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -91,27 +91,6 @@ export enum AppNavLinkStatus {
 }
 
 /**
- * Visibilities of the application
- *
- * @public
- */
-export enum AppVisibility {
-  /**
-   * The application visibility will be `both` if the application's {@link AppVisibility} is set to `default` or not set
-   * which means the application is visible within / out of workspace.
-   */
-  default = 0,
-  /**
-   * The application is only visible when user is inside a workspace.
-   */
-  workspaceOnly = 1,
-  /**
-   * The application is only visible when user is not in any workspace.
-   */
-  homeOnly = 2,
-}
-
-/**
  * Defines the list of fields that can be updated via an {@link AppUpdater}.
  * @public
  */
@@ -268,11 +247,9 @@ export interface App<HistoryLocationState = unknown> {
   exactRoute?: boolean;
 
   /**
-   * The visibility of the application based on workspace.
-   * Defaulting to `both`
-   * See {@link AppVisibility}
+   * Prevent the page to be accessible when inside a workspace. Defaults to `false`.
    */
-  visibility?: AppVisibility;
+  workspaceless?: boolean;
 }
 
 /**

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -263,7 +263,8 @@ export interface App<HistoryLocationState = unknown> {
   exactRoute?: boolean;
 
   /**
-   * Prevent the page to be accessible when inside a workspace. Defaults to `false`.
+   * Declare if page is accessible when inside a workspace.
+   * Defaults to undefined to indicate the application can be accessible within or out of workspace.
    */
   workspaceAccessibility?: WorkspaceAccessibility;
 }

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -272,7 +272,7 @@ export interface App<HistoryLocationState = unknown> {
    * Defaulting to `both`
    * See {@link AppVisibility}
    */
-  visibility: AppVisibility;
+  visibility?: AppVisibility;
 }
 
 /**

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -91,6 +91,27 @@ export enum AppNavLinkStatus {
 }
 
 /**
+ * Visibilities of the application
+ *
+ * @public
+ */
+export enum AppVisibility {
+  /**
+   * The application visibility will be `both` if the application's {@link AppVisibility} is set to `default` or not set
+   * which means the application is visible within / out of workspace.
+   */
+  default = 0,
+  /**
+   * The application is only visible when user is inside a workspace.
+   */
+  workspaceOnly = 1,
+  /**
+   * The application is only visible when user is not in any workspace.
+   */
+  homeOnly = 2,
+}
+
+/**
  * Defines the list of fields that can be updated via an {@link AppUpdater}.
  * @public
  */
@@ -245,6 +266,13 @@ export interface App<HistoryLocationState = unknown> {
    * ```
    */
   exactRoute?: boolean;
+
+  /**
+   * The visibility of the application based on workspace.
+   * Defaulting to `both`
+   * See {@link AppVisibility}
+   */
+  visibility: AppVisibility;
 }
 
 /**

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -264,7 +264,7 @@ export class ChromeService {
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
-          homeHref={http.basePath.prepend('/app/home', { withoutClientBasePath: true })}
+          homeHref={application.getUrlForApp('home')}
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -264,7 +264,7 @@ export class ChromeService {
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
-          homeHref={http.basePath.prepend('/app/home')}
+          homeHref={http.basePath.prepend('/app/home', { withoutClientBasePath: true })}
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -28,7 +28,12 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
+import {
+  PublicAppInfo,
+  AppNavLinkStatus,
+  AppStatus,
+  WorkspaceAccessibility,
+} from '../../application';
 import { toNavLink } from './to_nav_link';
 
 import { httpServiceMock } from '../../mocks';
@@ -171,6 +176,40 @@ describe('toNavLink', () => {
       expect.objectContaining({
         disabled: true,
         hidden: false,
+      })
+    );
+  });
+
+  it('uses the workspaceVisibility of the application to construct the url', () => {
+    const httpMock = httpServiceMock.createStartContract({
+      basePath: '/base_path',
+      clientBasePath: '/client_base_path',
+    });
+    expect(
+      toNavLink(
+        app({
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        }),
+        httpMock.basePath
+      ).properties
+    ).toEqual(
+      expect.objectContaining({
+        url: 'http://localhost/base_path/app/some-id',
+        baseUrl: 'http://localhost/base_path/app/some-id',
+      })
+    );
+
+    expect(
+      toNavLink(
+        app({
+          workspaceAccessibility: WorkspaceAccessibility.YES,
+        }),
+        httpMock.basePath
+      ).properties
+    ).toEqual(
+      expect.objectContaining({
+        url: 'http://localhost/base_path/client_base_path/app/some-id',
+        baseUrl: 'http://localhost/base_path/client_base_path/app/some-id',
       })
     );
   });

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -28,14 +28,17 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
+import { PublicAppInfo, AppNavLinkStatus, AppStatus, AppVisibility } from '../../application';
 import { IBasePath } from '../../http';
 import { NavLinkWrapper } from './nav_link';
 import { appendAppPath } from '../../application/utils';
 
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
-  const relativeBaseUrl = basePath.prepend(app.appRoute!);
+  let relativeBaseUrl = basePath.prepend(app.appRoute!);
+  if (app.visibility === AppVisibility.homeOnly) {
+    relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
+  }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));
   const baseUrl = relativeToAbsolute(relativeBaseUrl);
 

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -36,7 +36,7 @@ import { appendAppPath } from '../../application/utils';
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
   let relativeBaseUrl = basePath.prepend(app.appRoute!);
-  if (app.visibility === AppVisibility.homeOnly) {
+  if (app.workspaceless) {
     relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
   }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus, AppVisibility } from '../../application';
+import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
 import { IBasePath } from '../../http';
 import { NavLinkWrapper } from './nav_link';
 import { appendAppPath } from '../../application/utils';

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -28,7 +28,12 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
+import {
+  PublicAppInfo,
+  AppNavLinkStatus,
+  AppStatus,
+  WorkspaceAccessibility,
+} from '../../application';
 import { IBasePath } from '../../http';
 import { NavLinkWrapper } from './nav_link';
 import { appendAppPath } from '../../application/utils';
@@ -36,7 +41,7 @@ import { appendAppPath } from '../../application/utils';
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
   let relativeBaseUrl = basePath.prepend(app.appRoute!);
-  if (app.workspaceless) {
+  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
     relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
   }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -226,8 +226,8 @@ export class CoreSystem {
         overlays,
         targetDomElement: notificationsTargetDomElement,
       });
-      const application = await this.application.start({ http, overlays });
       const workspaces = this.workspaces.start();
+      const application = await this.application.start({ http, overlays, workspaces });
       const chrome = await this.chrome.start({
         application,
         docLinks,

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -130,6 +130,7 @@ export {
   AppUpdater,
   ScopedHistory,
   NavigateToAppOptions,
+  WorkspaceAccessibility,
 } from './application';
 
 export {

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -130,6 +130,7 @@ export {
   AppUpdater,
   ScopedHistory,
   NavigateToAppOptions,
+  AppVisibility,
 } from './application';
 
 export {

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -130,7 +130,6 @@ export {
   AppUpdater,
   ScopedHistory,
   NavigateToAppOptions,
-  AppVisibility,
 } from './application';
 
 export {

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -130,7 +130,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
-      visibility: AppVisibility.homeOnly,
+      workspaceless: true,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -54,7 +54,7 @@ import { DataPublicPluginStart } from '../../data/public';
 import { TelemetryPluginStart } from '../../telemetry/public';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
-import { AppNavLinkStatus, AppVisibility } from '../../../core/public';
+import { AppNavLinkStatus, WorkspaceAccessibility } from '../../../core/public';
 import { PLUGIN_ID, HOME_APP_BASE_PATH } from '../common/constants';
 import { DataSourcePluginStart } from '../../data_source/public';
 
@@ -130,7 +130,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
-      workspaceless: true,
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -54,7 +54,7 @@ import { DataPublicPluginStart } from '../../data/public';
 import { TelemetryPluginStart } from '../../telemetry/public';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
-import { AppNavLinkStatus } from '../../../core/public';
+import { AppNavLinkStatus, AppVisibility } from '../../../core/public';
 import { PLUGIN_ID, HOME_APP_BASE_PATH } from '../common/constants';
 import { DataSourcePluginStart } from '../../data_source/public';
 
@@ -130,6 +130,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
+      visibility: AppVisibility.homeOnly,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -40,6 +40,7 @@ import {
   AppStatus,
   AppNavLinkStatus,
   Branding,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 import {
   OpenSearchDashboardsOverviewPluginSetup,
@@ -106,6 +107,7 @@ export class OpenSearchDashboardsOverviewPlugin
         // Render the application
         return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
       },
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     if (home) {

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -93,7 +93,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/create workspace/i));
-    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_create');
+    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_create');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,
@@ -111,7 +111,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/all workspace/i));
-    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_list');
+    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_list');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -101,13 +101,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_CREATE_APP_ID,
       onClick: () => {
-        window.location.assign(
-          cleanWorkspaceId(
-            coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
-              absolute: false,
-            })
-          )
-        );
+        coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
       },
     });
     workspaceListItems.push({
@@ -117,13 +111,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_LIST_APP_ID,
       onClick: () => {
-        window.location.assign(
-          cleanWorkspaceId(
-            coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
-              absolute: false,
-            })
-          )
-        );
+        coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
       },
     });
     return workspaceListItems;

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -140,6 +140,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
+      workspaceless: true,
     });
 
     // create
@@ -153,6 +154,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         const { renderCreatorApp } = await import('./application');
         return mountWorkspaceApp(params, renderCreatorApp);
       },
+      workspaceless: true,
     });
 
     // update

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -14,6 +14,7 @@ import {
   Plugin,
   AppUpdater,
   AppStatus,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 import {
   WORKSPACE_FATAL_ERROR_APP_ID,
@@ -140,7 +141,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
-      workspaceless: true,
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     // create
@@ -154,7 +155,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
         const { renderCreatorApp } = await import('./application');
         return mountWorkspaceApp(params, renderCreatorApp);
       },
-      workspaceless: true,
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     // update

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -8,7 +8,7 @@ import {
   getSelectedFeatureQuantities,
   isAppAccessibleInWorkspace,
 } from './utils';
-import { PublicAppInfo } from '../../../core/public';
+import { PublicAppInfo, WorkspaceAccessibility } from '../../../core/public';
 import { AppNavLinkStatus } from '../../../core/public';
 
 describe('workspace utils: featureMatchesConfig', () => {
@@ -197,5 +197,19 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )
     ).toBe(true);
+  });
+
+  it('An app is not accessible if its workspaceAccessibility is no', () => {
+    expect(
+      isAppAccessibleInWorkspace(
+        {
+          id: 'home',
+          title: 'Any app',
+          mount: jest.fn(),
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        },
+        { id: 'workspace_id', name: 'workspace name', features: [] }
+      )
+    ).toBe(false);
   });
 });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -10,6 +10,7 @@ import {
   AppNavLinkStatus,
   DEFAULT_APP_CATEGORIES,
   WorkspaceObject,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 
 /**
@@ -94,6 +95,13 @@ export const getSelectedFeatureQuantities = (
  * Check if an app is accessible in a workspace based on the workspace configured features
  */
 export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject) {
+  /**
+   * App is not accessible within workspace if it explicitly declare itself as workspaceAccessibility.No
+   */
+  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
+    return false;
+  }
+
   /**
    * When workspace has no features configured, all apps are considered to be accessible
    */

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -49,6 +49,9 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       options: SavedObjectsCreateOptions = {}
     ) => {
       const { workspaces, id, overwrite } = options;
+      if (!id || !overwrite) {
+        return await wrapperOptions.client.create(type, attributes, options);
+      }
       let savedObjectWorkspaces = options?.workspaces;
 
       /**
@@ -90,6 +93,9 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       options: SavedObjectsCreateOptions = {}
     ): Promise<SavedObjectsBulkResponse<T>> => {
       const { overwrite, namespace } = options;
+      if (!overwrite) {
+        return await wrapperOptions.client.bulkCreate(objects, options);
+      }
       /**
        * When overwrite, filter out all the objects that have ids
        */

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -49,9 +49,6 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       options: SavedObjectsCreateOptions = {}
     ) => {
       const { workspaces, id, overwrite } = options;
-      if (!id || !overwrite) {
-        return await wrapperOptions.client.create(type, attributes, options);
-      }
       let savedObjectWorkspaces = options?.workspaces;
 
       /**
@@ -93,9 +90,6 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       options: SavedObjectsCreateOptions = {}
     ): Promise<SavedObjectsBulkResponse<T>> => {
       const { overwrite, namespace } = options;
-      if (!overwrite) {
-        return await wrapperOptions.client.bulkCreate(objects, options);
-      }
       /**
        * When overwrite, filter out all the objects that have ids
        */


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Home page, which is supposed to be only visited without workspace, now is enabled to be accessed by clicking the home icon or enter the url manually in the browser.

This PR introduces a new field `AppVisibility` inside App, which indicates the visibility of the application. This field can bring two benefits:
1. When navigate between apps, plugins and core application are using the `navigateToApp` method. By using the visibility field, workspace is able to do the hard navigation in a central place.
2. The AppVisibility field can be used in workspace create page to filter applications that should not be visible inside workspace. For now we filter out home overview page and all the pages under management section by hard code, which is not elegant and extensible.

Extending the `status` field should work as well.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6362

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![20240407094009141](https://github.com/ruanyl/OpenSearch-Dashboards/assets/13493605/f6937943-2d95-4bfb-b8ca-27631ce436a4)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
