### PR TITLE
Migrate explore area chart from vega-lite to echarts

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
@@ -1,0 +1,541 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  StandardAxes,
+  VisFieldType,
+  VisColumn,
+  TimeUnit,
+  AggregationType,
+  AxisRole,
+} from '../types';
+import { applyAxisStyling, getSchemaByAxis } from '../utils/utils';
+import { AreaChartStyle } from './area_vis_config';
+import { getColors, DEFAULT_GREY } from '../theme/default_colors';
+import { BaseChartStyle, EChartsSpecState, PipelineFn } from '../utils/echarts_spec';
+
+export const inferTimeIntervals = (data: Array<Record<string, any>>, field: string | undefined) => {
+  if (!data || data.length === 0 || !field) {
+    return TimeUnit.DATE;
+  }
+
+  const timestamps = data
+    .map((row) => new Date(row[field]).getTime())
+    .filter((t) => !isNaN(t))
+    .sort((a, b) => a - b);
+
+  const last = timestamps[timestamps.length - 1];
+  const first = timestamps[0];
+  const minDiff = last - first;
+
+  const interval = minDiff / 30;
+
+  const second = 1000;
+  const minute = 60 * second;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const month = 30 * day;
+
+  if (interval <= second) return TimeUnit.SECOND;
+  if (interval <= minute) return TimeUnit.MINUTE;
+  if (interval <= hour) return TimeUnit.HOUR;
+  if (interval <= day) return TimeUnit.DATE;
+  if (interval <= month) return TimeUnit.MONTH;
+  return TimeUnit.YEAR;
+};
+
+export const transformIntervalsToTickCount = (interval: TimeUnit | undefined) => {
+  switch (interval) {
+    case TimeUnit.YEAR:
+      return 'year';
+    case TimeUnit.MONTH:
+      return 'month';
+    case TimeUnit.DATE:
+      return 'day';
+    case TimeUnit.HOUR:
+      return 'hour';
+    case TimeUnit.MINUTE:
+      return 'minute';
+    case TimeUnit.SECOND:
+      return 'second';
+    default:
+      return 'day';
+  }
+};
+
+export const buildEncoding = (
+  axis: VisColumn | undefined,
+  axisStyle: StandardAxes | undefined,
+  interval: TimeUnit | undefined,
+  aggregationType?: AggregationType | undefined
+) => {
+  const defaultAxisTitle = '';
+  const encoding: any = {
+    field: axis?.column,
+    type: getSchemaByAxis(axis),
+    axis: applyAxisStyling({ axis, axisStyle, defaultAxisTitle }),
+  };
+
+  if (axis?.schema === VisFieldType.Date && interval) {
+    encoding.timeUnit = interval;
+    encoding.axis.tickCount = transformIntervalsToTickCount(interval);
+  }
+
+  if (axis?.schema === VisFieldType.Numerical && aggregationType) {
+    encoding.aggregate = aggregationType;
+  }
+
+  return encoding;
+};
+
+export const buildTooltipEncoding = (
+  axis: VisColumn | undefined,
+  axisStyle: StandardAxes | undefined,
+  interval: TimeUnit | undefined,
+  aggregationType?: AggregationType | undefined
+) => {
+  const encoding: any = {
+    field: axis?.column,
+    type: getSchemaByAxis(axis),
+    title: axisStyle?.title?.text || axis?.name,
+  };
+
+  if (axis?.schema === VisFieldType.Date && interval) {
+    encoding.timeUnit = interval;
+  }
+
+  if (axis?.schema === VisFieldType.Numerical && aggregationType) {
+    encoding.aggregate = aggregationType;
+    encoding.title = axisStyle?.title?.text || `${axis?.name}(${aggregationType})`;
+  }
+  return encoding;
+};
+
+export const buildThresholdColorEncoding = (
+  numericalField: VisColumn | undefined,
+  styleOptions: Partial<AreaChartStyle>
+) => {
+  // support old thresholdLines config to be compatible with new thresholds
+
+  const activeThresholds = styleOptions?.thresholdOptions?.thresholds ?? [];
+
+  const thresholdWithBase = [
+    { value: 0, color: styleOptions?.thresholdOptions?.baseColor ?? getColors().statusGreen },
+    ...activeThresholds,
+  ];
+
+  const colorDomain = thresholdWithBase.reduce<number[]>((acc, val) => [...acc, val.value], []);
+
+  const colorRange = thresholdWithBase.reduce<string[]>((acc, val) => [...acc, val.color], []);
+
+  // exclusive for single numerical bucket area
+  if (!numericalField)
+    return {
+      aggregate: AggregationType.COUNT,
+      type: 'quantitative',
+      scale: {
+        type: 'threshold',
+        domain: colorDomain,
+        // require one more color for values below the first threshold(base)
+        range: [DEFAULT_GREY, ...colorRange],
+      },
+      legend: styleOptions.addLegend
+        ? {
+            orient: styleOptions.legendPosition?.toLowerCase() || 'right',
+            title: 'Thresholds',
+          }
+        : null,
+    };
+
+  const colorLayer = {
+    field: numericalField?.column,
+    type: 'quantitative',
+    scale: {
+      type: 'threshold',
+      domain: colorDomain,
+      range: [DEFAULT_GREY, ...colorRange],
+    },
+    legend: styleOptions.addLegend
+      ? {
+          orient: styleOptions.legendPosition?.toLowerCase() || 'right',
+          title: 'Thresholds',
+        }
+      : null,
+  };
+
+  return colorLayer;
+};
+
+/**
+ * Create area series configuration for ECharts
+ */
+export const createAreaSeries = <T extends BaseChartStyle>(
+  styles: AreaChartStyle
+): PipelineFn<T> => (state) => {
+  const { axisConfig, data, axisColumnMappings } = state;
+  const newState = { ...state };
+  newState.series = [];
+  delete newState.spec;
+
+  if (!axisConfig) {
+    throw new Error('axisConfig must be derived before createAreaSeries');
+  }
+
+  const numericalAxis = [axisConfig.xAxis, axisConfig.yAxis].find(
+    (axis) => axis?.schema === VisFieldType.Numerical
+  );
+
+  // Check if we have multiple series (color mapping exists)
+  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
+  const hasMultipleSeries = !!colorColumn;
+
+  // Ensure we have valid column names
+  const xColumn = axisConfig.xAxis?.column;
+  const yColumn = axisConfig.yAxis?.column;
+
+  if (!xColumn || !yColumn) {
+    throw new Error('Both X and Y axis columns must be defined for area chart');
+  }
+
+  // Check if x-axis is categorical (not time-based)
+  const isXAxisCategorical = axisConfig.xAxis?.schema === VisFieldType.Categorical;
+
+  if (hasMultipleSeries) {
+    // Multi-series area chart - create separate series for each category
+    const colorColumnName = colorColumn.column;
+    const uniqueValues = Array.from(new Set(data.map((row) => row[colorColumnName])));
+
+    if (isXAxisCategorical) {
+      // For categorical x-axis, aggregate data by category
+      // Get all unique categories and sort them for consistent ordering
+      const allCategories = Array.from(new Set(data.map((row) => row[xColumn]))).sort((a, b) =>
+        String(a).localeCompare(String(b))
+      );
+
+      const series: any[] = uniqueValues.map((value) => {
+        // Aggregate data for this series by x-axis category
+        const categoryMap = new Map();
+        data
+          .filter((row) => row[colorColumnName] === value)
+          .forEach((row) => {
+            const category = row[xColumn];
+            const currentValue = categoryMap.get(category) || 0;
+            categoryMap.set(category, currentValue + (row[yColumn] || 0));
+          });
+
+        // Create ordered series data based on sorted categories
+        const seriesData = allCategories.map((category) => [
+          category,
+          categoryMap.get(category) || 0,
+        ]);
+
+        return {
+          type: 'line',
+          name: String(value),
+          data: seriesData,
+          stack: 'Total',
+          areaStyle: {
+            opacity: styles.areaOpacity || 0.3,
+          },
+          smooth: false,
+        };
+      });
+
+      newState.series = series;
+    } else {
+      // For time-based x-axis, use time alignment
+      const allTimePoints = Array.from(new Set(data.map((row) => row[xColumn]))).sort(
+        (a, b) => new Date(a).getTime() - new Date(b).getTime()
+      );
+
+      const series: any[] = uniqueValues.map((value) => {
+        const seriesMap = new Map();
+        data
+          .filter((row) => row[colorColumnName] === value)
+          .forEach((row) => {
+            const existingValue = seriesMap.get(row[xColumn]) || 0;
+            seriesMap.set(row[xColumn], existingValue + (row[yColumn] || 0));
+          });
+
+        const seriesData = allTimePoints.map((timePoint) => [
+          timePoint,
+          seriesMap.get(timePoint) || 0,
+        ]);
+
+        return {
+          type: 'line',
+          name: String(value),
+          data: seriesData,
+          stack: 'Total',
+          areaStyle: {
+            opacity: styles.areaOpacity || 0.3,
+          },
+          smooth: true,
+        };
+      });
+
+      newState.series = series;
+    }
+  } else {
+    // Single series area chart
+    let seriesData;
+
+    if (isXAxisCategorical) {
+      // For categorical x-axis, aggregate data by category
+      // Get all unique categories and sort them for consistent ordering
+      const allCategories = Array.from(new Set(data.map((row) => row[xColumn]))).sort((a, b) =>
+        String(a).localeCompare(String(b))
+      );
+
+      const categoryMap = new Map();
+      data.forEach((row) => {
+        const category = row[xColumn];
+        const currentValue = categoryMap.get(category) || 0;
+        categoryMap.set(category, currentValue + (row[yColumn] || 0));
+      });
+
+      // Create ordered series data based on sorted categories
+      seriesData = allCategories.map((category) => [category, categoryMap.get(category) || 0]);
+    } else {
+      // For time-based x-axis, sort by time
+      seriesData = data
+        .map((row) => [row[xColumn], row[yColumn]])
+        .sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
+    }
+
+    const series: any[] = [
+      {
+        type: 'line',
+        name: numericalAxis?.name || '',
+        data: seriesData,
+        areaStyle: {
+          opacity: styles.areaOpacity || 0.3,
+        },
+        smooth: !isXAxisCategorical, // Only smooth for time-based axes
+      },
+    ];
+
+    newState.series = series;
+  }
+
+  return newState;
+};
+
+/**
+ * Create faceted area series configuration for ECharts
+ * Implements proper multi-grid faceting based on official ECharts pattern
+ */
+export const createFacetedAreaSeries = <T extends BaseChartStyle>(
+  styles: AreaChartStyle
+): PipelineFn<T> => (state) => {
+  const { axisConfig, data, axisColumnMappings } = state;
+  const newState = { ...state };
+  newState.series = [];
+  delete newState.spec;
+
+  if (!axisConfig) {
+    throw new Error('axisConfig must be derived before createFacetedAreaSeries');
+  }
+
+  // Get facet column and color column
+  const facetColumn = axisColumnMappings?.[AxisRole.FACET];
+  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
+
+  if (!facetColumn) {
+    return createAreaSeries(styles)(state) as EChartsSpecState<T>;
+  }
+
+  // Ensure we have valid column names
+  const xColumn = axisConfig.xAxis?.column;
+  const yColumn = axisConfig.yAxis?.column;
+  const facetColumnName = facetColumn.column;
+
+  if (!xColumn || !yColumn) {
+    throw new Error('Both X and Y axis columns must be defined for faceted area chart');
+  }
+
+  // Get unique values for faceting and stacking
+  const uniqueFacetValues = Array.from(new Set(data.map((row) => row[facetColumnName]))).filter(
+    (val) => val !== null && val !== undefined && val !== ''
+  );
+  const uniqueColorValues = colorColumn
+    ? Array.from(new Set(data.map((row) => row[colorColumn.column]))).filter(
+        (val) => val !== null && val !== undefined
+      )
+    : ['default'];
+
+  // Check if x-axis is categorical
+  const isXAxisCategorical = axisConfig.xAxis?.schema === VisFieldType.Categorical;
+
+  // Create grids, axes, and series for each facet
+  const grids: any[] = [];
+  const xAxes: any[] = [];
+  const yAxes: any[] = [];
+  const series: any[] = [];
+
+  const numFacets = uniqueFacetValues.length;
+
+  if (numFacets < 1) {
+    // No facets, fall back to regular area chart
+    return createAreaSeries(styles)(state) as EChartsSpecState<T>;
+  }
+
+  // Create grids dynamically based on number of facets
+  if (numFacets === 1) {
+    // Single grid
+    grids.push({ left: '10%', width: '80%', top: '10%', height: '70%' });
+  } else if (numFacets === 2) {
+    // Side by side
+    grids.push(
+      { left: '7%', width: '38%', top: '10%', height: '70%' },
+      { left: '55%', width: '38%', top: '10%', height: '70%' }
+    );
+  } else if (numFacets === 3) {
+    // 3 facets: use scrolling layout
+    const baseGridWidth = 30;
+    const marginBetweenGrids = 5;
+
+    for (let i = 0; i < numFacets; i++) {
+      grids.push({
+        left: `${5 + i * (baseGridWidth + marginBetweenGrids)}%`,
+        width: `${baseGridWidth}%`,
+        top: '10%',
+        height: '70%',
+      });
+    }
+  } else if (numFacets === 4) {
+    // 4 facets: 2x2 grid layout
+    const positions = [
+      { left: '7%', width: '38%', top: '10%', height: '35%' }, // top-left
+      { left: '55%', width: '38%', top: '10%', height: '35%' }, // top-right
+      { left: '7%', width: '38%', top: '55%', height: '35%' }, // bottom-left
+      { left: '55%', width: '38%', top: '55%', height: '35%' }, // bottom-right
+    ];
+    for (let i = 0; i < numFacets; i++) {
+      grids.push(positions[i]);
+    }
+  } else {
+    // For 5+ facets, use horizontal scrolling layout with fixed-size grids
+    const targetGridWidth = 30; // Target width as percentage of viewport (not container)
+    const marginBetweenGrids = 3; // Margin as percentage of viewport
+    const numCols = Math.ceil(numFacets / 2); // Number of columns needed
+
+    // Calculate total width needed
+    const totalWidthNeeded = 6 + numCols * (targetGridWidth + marginBetweenGrids);
+
+    // Adjust grid width to maintain target size relative to viewport
+    const adjustedGridWidth = (targetGridWidth * 100) / totalWidthNeeded;
+    const adjustedMargin = (marginBetweenGrids * 100) / totalWidthNeeded;
+
+    // Simple 2-row layout, grids distributed across rows
+    for (let i = 0; i < numFacets; i++) {
+      const row = i % 2; // Alternate between row 0 and 1
+      const colInRow = Math.floor(i / 2); // Column position (0, 1, 2, ...)
+
+      grids.push({
+        left: `${(3 * 100) / totalWidthNeeded + colInRow * (adjustedGridWidth + adjustedMargin)}%`,
+        width: `${adjustedGridWidth}%`,
+        top: `${10 + row * 45}%`,
+        height: '35%',
+      });
+    }
+  }
+
+  // Create axes dynamically
+  for (let i = 0; i < numFacets; i++) {
+    xAxes.push({ type: isXAxisCategorical ? 'category' : 'time', gridIndex: i });
+    yAxes.push({ type: 'value', gridIndex: i });
+  }
+
+  // Create series for each facet
+  for (let facetIndex = 0; facetIndex < numFacets; facetIndex++) {
+    const facetValue = uniqueFacetValues[facetIndex];
+
+    // Get all data for this facet
+    const facetData = data.filter((row) => row[facetColumnName] === facetValue);
+
+    if (facetData.length === 0) {
+      continue;
+    }
+
+    // Get time points for this specific facet only
+    const facetTimePoints = isXAxisCategorical
+      ? Array.from(new Set(facetData.map((row) => row[xColumn]))).sort((a, b) =>
+          String(a).localeCompare(String(b))
+        )
+      : Array.from(new Set(facetData.map((row) => row[xColumn]))).sort(
+          (a, b) => new Date(a).getTime() - new Date(b).getTime()
+        );
+
+    // Create series for each color value within this facet
+    uniqueColorValues.forEach((colorValue) => {
+      const colorData = facetData.filter(
+        (row) => !colorColumn || row[colorColumn.column] === colorValue
+      );
+
+      if (colorData.length === 0) return;
+
+      // Aggregate data by time points
+      let seriesData;
+      if (isXAxisCategorical) {
+        const categoryMap = new Map();
+        colorData.forEach((row) => {
+          const category = row[xColumn];
+          const currentValue = categoryMap.get(category) || 0;
+          categoryMap.set(category, currentValue + (row[yColumn] || 0));
+        });
+        seriesData = facetTimePoints.map((category) => [category, categoryMap.get(category) || 0]);
+      } else {
+        const timeMap = new Map();
+        colorData.forEach((row) => {
+          const timePoint = row[xColumn];
+          const currentValue = timeMap.get(timePoint) || 0;
+          timeMap.set(timePoint, currentValue + (row[yColumn] || 0));
+        });
+        seriesData = facetTimePoints.map((timePoint) => [timePoint, timeMap.get(timePoint) || 0]);
+      }
+
+      const seriesName = colorColumn
+        ? String(colorValue || 'Unknown')
+        : String(facetValue || 'Unknown');
+
+      series.push({
+        type: 'line',
+        name: seriesName,
+        data: seriesData,
+        xAxisIndex: facetIndex,
+        yAxisIndex: facetIndex,
+        stack: `Total_${facetIndex}`,
+        areaStyle: { opacity: styles.areaOpacity || 0.3 },
+        smooth: !isXAxisCategorical,
+      });
+    });
+  }
+
+  // Calculate total width needed for horizontal scrolling
+  let totalWidthPercent = 100; // Default width percentage
+
+  if (numFacets === 3) {
+    // 3 facets in a row
+    const baseGridWidth = 30;
+    const marginBetweenGrids = 5;
+    totalWidthPercent = Math.max(100, 10 + numFacets * (baseGridWidth + marginBetweenGrids));
+  } else if (numFacets > 4) {
+    // 5+ facets in 2 rows - calculate based on target viewport sizes
+    const targetGridWidth = 30; // Target width as percentage of viewport
+    const marginBetweenGrids = 3; // Margin as percentage of viewport
+    const numCols = Math.ceil(numFacets / 2); // Number of columns (since we have 2 rows)
+    totalWidthPercent = Math.max(100, 6 + numCols * (targetGridWidth + marginBetweenGrids));
+  }
+
+  // Set the grids, axes, and series in the state
+  (newState as any).grids = grids;
+  (newState as any).xAxes = xAxes;
+  (newState as any).yAxes = yAxes;
+  (newState as any).totalWidth = totalWidthPercent; // Pass total width for scrolling
+  newState.series = series;
+
+  return newState;
+};

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -7,10 +7,24 @@ import { AreaChartStyle } from './area_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import { buildMarkConfig, createTimeMarkerLayer, applyAxisStyling } from '../line/line_chart_utils';
 import { createThresholdLayer } from '../style_panel/threshold/threshold_utils';
-import { applyTimeRangeToEncoding, getSwappedAxisRole, getTooltipFormat } from '../utils/utils';
+import {
+  applyTimeRangeToEncoding,
+  getSwappedAxisRole,
+  getTooltipFormat,
+  getChartRender,
+} from '../utils/utils';
 import { DEFAULT_OPACITY } from '../constants';
 import { createCrosshairLayers, createHighlightBarLayers } from '../utils/create_hover_state';
 import { createTimeRangeBrush, createTimeRangeUpdater } from '../utils/time_range_brush';
+import {
+  pipe,
+  deriveAxisConfig,
+  prepareData,
+  createBaseConfig,
+  buildAxisConfigs,
+  assembleSpec,
+} from '../utils/echarts_spec';
+import { createAreaSeries, createFacetedAreaSeries } from './area_chart_utils';
 
 /**
  * Create a simple area chart with one metric and one date
@@ -32,6 +46,23 @@ export const createSimpleAreaChart = (
   const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
   const metricField = yAxis?.column;
   const dateField = xAxis?.column;
+  // Check if we should use ECharts rendering
+  if (getChartRender() === 'echarts') {
+    const result = pipe(
+      deriveAxisConfig,
+      prepareData,
+      createBaseConfig,
+      buildAxisConfigs,
+      createAreaSeries(styles),
+      assembleSpec
+    )({
+      data: transformedData,
+      styles,
+      axisColumnMappings,
+    });
+
+    return result.spec;
+  }
 
   const metricName = yAxisStyle?.title?.text || yAxis?.name;
   const dateName = xAxisStyle?.title?.text || xAxis?.name;
@@ -161,6 +192,24 @@ export const createMultiAreaChart = (
   axisColumnMappings?: AxisColumnMappings,
   timeRange?: { from: string; to: string }
 ): any => {
+  // Check if we should use ECharts rendering
+  if (getChartRender() === 'echarts') {
+    const result = pipe(
+      deriveAxisConfig,
+      prepareData,
+      createBaseConfig,
+      buildAxisConfigs,
+      createAreaSeries(styles),
+      assembleSpec
+    )({
+      data: transformedData,
+      styles,
+      axisColumnMappings,
+    });
+
+    return result.spec;
+  }
+
   const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
 
   const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
@@ -309,6 +358,24 @@ export const createFacetedMultiAreaChart = (
   axisColumnMappings?: AxisColumnMappings,
   timeRange?: { from: string; to: string }
 ): any => {
+  // Check if we should use ECharts rendering
+  if (getChartRender() === 'echarts') {
+    const result = pipe(
+      deriveAxisConfig,
+      prepareData,
+      createBaseConfig,
+      buildAxisConfigs,
+      createFacetedAreaSeries(styles),
+      assembleSpec
+    )({
+      data: transformedData,
+      styles,
+      axisColumnMappings,
+    });
+
+    return result.spec;
+  }
+
   const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
   const facetMapping = axisColumnMappings?.[AxisRole.FACET];
 
@@ -489,6 +556,23 @@ export const createCategoryAreaChart = (
   const categoryField = xAxis?.column;
   const metricName = yAxisStyle?.title?.text || yAxis?.name;
   const categoryName = xAxisStyle?.title?.text || xAxis?.name;
+  // Check if we should use ECharts rendering
+  if (getChartRender() === 'echarts') {
+    const result = pipe(
+      deriveAxisConfig,
+      prepareData,
+      createBaseConfig,
+      buildAxisConfigs,
+      createAreaSeries(styles),
+      assembleSpec
+    )({
+      data: transformedData,
+      styles,
+      axisColumnMappings,
+    });
+
+    return result.spec;
+  }
   const layers: any[] = [];
   const showTooltip = styles.tooltipOptions?.mode !== 'hidden';
 
@@ -588,6 +672,24 @@ export const createStackedAreaChart = (
   styles: AreaChartStyle,
   axisColumnMappings?: AxisColumnMappings
 ): any => {
+  // Check if we should use ECharts rendering
+  if (getChartRender() === 'echarts') {
+    const result = pipe(
+      deriveAxisConfig,
+      prepareData,
+      createBaseConfig,
+      buildAxisConfigs,
+      createAreaSeries(styles),
+      assembleSpec
+    )({
+      data: transformedData,
+      styles,
+      axisColumnMappings,
+    });
+
+    return result.spec;
+  }
+
   const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
   const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 

--- a/src/plugins/explore/public/components/visualizations/echarts_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/echarts_render.tsx
@@ -43,9 +43,58 @@ export const EchartsRender = ({ spec }: Props) => {
 
   useEffect(() => {
     if (instance && spec) {
-      instance.setOption({ ...spec, grid: { top: 60, bottom: 60, left: 60, right: 60 } });
+      // Check if this is a multi-grid (faceted) chart
+      const isMultiGrid = Array.isArray(spec.grid);
+
+      const finalSpec = isMultiGrid
+        ? spec // Use the multi-grid spec as-is
+        : { ...spec, grid: { top: 60, bottom: 60, left: 60, right: 60 } }; // Apply default grid for single charts
+
+      instance.setOption(finalSpec, { notMerge: true });
+
+      // Force resize after setting options, especially important for scrolling layouts
+      setTimeout(() => {
+        if (instance) {
+          instance.resize();
+        }
+      }, 0);
     }
   }, [spec, instance]);
 
-  return <div style={{ height: '100%', width: '100%' }} ref={containerRef} />;
+  // Check if we need horizontal scrolling
+  const specWithWidth = spec as any;
+  const totalWidthPercent = specWithWidth?.totalWidth || 100;
+  const needsScrolling = totalWidthPercent > 100;
+
+  // Use calculated width based on actual requirements
+  const containerStyle: React.CSSProperties = {
+    height: '100%',
+    width: needsScrolling ? `${totalWidthPercent}%` : '100%',
+    minWidth: needsScrolling ? `${totalWidthPercent}%` : '100%',
+  };
+
+  const wrapperStyle: React.CSSProperties = needsScrolling
+    ? {
+        height: '100%',
+        width: '100%',
+        overflowX: 'auto',
+        overflowY: 'hidden',
+        position: 'relative',
+      }
+    : { height: '100%', width: '100%' };
+
+  return (
+    <div
+      style={wrapperStyle}
+      onWheel={(e) => {
+        // Force horizontal scrolling with mouse wheel
+        if (needsScrolling && e.deltaY !== 0) {
+          e.currentTarget.scrollLeft += e.deltaY;
+          e.preventDefault();
+        }
+      }}
+    >
+      <div style={containerStyle} ref={containerRef} />
+    </div>
+  );
 };

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -238,14 +238,33 @@ export const assembleSpec = <T extends BaseChartStyle>(
   state: EChartsSpecState<T>
 ): EChartsSpecState<T> => {
   const { baseConfig, aggregatedData, xAxisConfig, yAxisConfig, series } = state;
+  const stateWithGrids = state as any;
+
+  // Check if this is a multi-grid (faceted) chart
+  const isMultiGrid = !!(stateWithGrids.grids && stateWithGrids.xAxes && stateWithGrids.yAxes);
 
   const spec = {
     ...baseConfig,
-    dataset: { source: aggregatedData },
-    xAxis: xAxisConfig,
-    yAxis: yAxisConfig,
+    ...(isMultiGrid
+      ? {
+          // Multi-grid configuration for faceted charts - don't use dataset
+          grid: stateWithGrids.grids, // ECharts expects 'grid' for arrays
+          xAxis: stateWithGrids.xAxes, // ECharts expects 'xAxis' for arrays
+          yAxis: stateWithGrids.yAxes, // ECharts expects 'yAxis' for arrays
+        }
+      : {
+          // Single-grid configuration for regular charts
+          dataset: { source: aggregatedData },
+          xAxis: xAxisConfig,
+          yAxis: yAxisConfig,
+        }),
     series,
   };
+
+  // Copy totalWidth from state to spec for scrolling support
+  if (stateWithGrids.totalWidth) {
+    (spec as any).totalWidth = stateWithGrids.totalWidth;
+  }
 
   return { ...state, spec };
 };


### PR DESCRIPTION
### Description

This PR migrates the area chart visualization in the explore plugin from vega-lite to echarts.


## Screenshot
### Simple area chart
<img width="2860" height="1302" alt="image" src="https://github.com/user-attachments/assets/3ad6da1e-f1b4-430e-bd0a-70aadad434c3" />

### Multi-area chart
<img width="2922" height="1298" alt="image" src="https://github.com/user-attachments/assets/b6942599-6ca2-4dcc-9f9e-9f1497ebd123" />

### Faceted multi-area chart
<img width="2910" height="1296" alt="image" src="https://github.com/user-attachments/assets/9eb2b4b5-f4fb-453f-93e5-24bb88783554" />

### Category-based area chart
<img width="2912" height="1298" alt="image" src="https://github.com/user-attachments/assets/3582e1a4-39ef-421d-9796-63e3083e116d" />


### Category-based stacked area chart
<img width="2922" height="1306" alt="image" src="https://github.com/user-attachments/assets/8a73ebf9-26e1-4729-a37c-6fc4844a7435" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- feat: Migrate explore area chart from vega-lite to echarts

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
